### PR TITLE
Api swr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
                 "@navikt/navspa": "^6.0.1",
                 "constate": "^3.3.2",
                 "react": "^18.2.0",
-                "react-dom": "^18.2.0"
+                "react-dom": "^18.2.0",
+                "swr": "^2.2.0"
             },
             "devDependencies": {
                 "@testing-library/react": "^14.0.0",
@@ -5761,6 +5762,17 @@
                 "node": ">=4"
             }
         },
+        "node_modules/swr": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.0.tgz",
+            "integrity": "sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==",
+            "dependencies": {
+                "use-sync-external-store": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -5991,6 +6003,14 @@
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
+            }
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/util": {
@@ -10526,6 +10546,14 @@
                 "has-flag": "^3.0.0"
             }
         },
+        "swr": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.0.tgz",
+            "integrity": "sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==",
+            "requires": {
+                "use-sync-external-store": "^1.2.0"
+            }
+        },
         "symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -10691,6 +10719,12 @@
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
             }
+        },
+        "use-sync-external-store": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+            "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+            "requires": {}
         },
         "util": {
             "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "@navikt/navspa": "^6.0.1",
         "constate": "^3.3.2",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "swr": "^2.2.0"
     },
     "devDependencies": {
         "@testing-library/react": "^14.0.0",

--- a/src/components/cv-innhold.tsx
+++ b/src/components/cv-innhold.tsx
@@ -22,17 +22,38 @@ const CvInnhold = () => {
     const { fnr } = useAppStore();
 
     const cvOgJobbonsker = useCvOgJobbonsker(fnr);
-    console.log('TEST CV:', cvOgJobbonsker.data, cvOgJobbonsker.isLoading, cvOgJobbonsker.error);
-    console.log('ERROR CV:', cvOgJobbonsker.error?.info);
-
     const underOppfolging = useUnderOppfolging(fnr);
-    console.log('TEST OPPFØLGNING:', underOppfolging.data, underOppfolging.isLoading, underOppfolging.error);
-    console.log('ERROR OPPFØLGING:', underOppfolging.error?.info);
 
     if (cvOgJobbonsker.isLoading || underOppfolging.isLoading) {
         return (
             <Panel border className="info_panel" tabIndex={2}>
                 <Laster />
+            </Panel>
+        );
+    }
+
+    if (cvOgJobbonsker?.error?.status === 401 || cvOgJobbonsker?.error?.status === 403) {
+        return (
+            <Panel border className="info_panel" tabIndex={2}>
+                <Heading spacing level="2" size="medium" className="PanelHeader">
+                    CV
+                </Heading>
+                <Alert inline variant="info">
+                    Du har ikke tilgang til CV
+                </Alert>
+            </Panel>
+        );
+    }
+
+    if (cvOgJobbonsker?.error?.status === 204 || cvOgJobbonsker?.error?.status === 404) {
+        return (
+            <Panel border className="info_panel" tabIndex={2}>
+                <Heading spacing level="2" size="medium" className="PanelHeader">
+                    CV
+                </Heading>
+                <Alert inline variant="info">
+                    Ingen CV registrert
+                </Alert>
             </Panel>
         );
     }
@@ -49,8 +70,7 @@ const CvInnhold = () => {
     }
 
     const erManuell = underOppfolging.data?.erManuell;
-
-    if (cvOgJobbonsker.data) {
+    if (cvOgJobbonsker.data && Object.keys(cvOgJobbonsker.data).length) {
         const {
             fagdokumentasjoner,
             sammendrag,
@@ -95,9 +115,7 @@ const CvInnhold = () => {
             <Heading spacing level="2" size="medium" className="PanelHeader">
                 CV
             </Heading>
-            <Alert inline variant="info">
-                Ingen CV registrert
-            </Alert>
+            <Errormelding />
         </Panel>
     );
 };

--- a/src/components/cv-innhold.tsx
+++ b/src/components/cv-innhold.tsx
@@ -1,12 +1,7 @@
-import { useEffect, useState } from 'react';
-// import { useSWRConfig } from 'swr';
-import useSWR from 'swr';
 import { useAppStore } from '../stores/app-store';
-import { ArenaPerson } from '../data/api/datatyper/arenaperson';
-import { UnderOppfolgingData } from '../data/api/datatyper/underOppfolgingData';
 import { LastNedCV } from './cv/last-ned-cv';
 import { RedigerCV } from './cv/rediger-cv';
-import { hentCvOgJobbonsker, hentUnderOppfolging, hentCvOgJobbonskerv2, ErrorTest } from '../data/api/fetch';
+import { useCvOgJobbonsker, useUnderOppfolging } from '../data/api/fetchv2';
 import { Heading, Panel, Alert } from '@navikt/ds-react';
 import { Errormelding, Laster } from './felles/minikomponenter';
 import SistEndret from './felles/sist-endret';
@@ -23,67 +18,16 @@ import Kompetanser from './cv/kompetanser';
 import Fagdokumentasjoner from './cv/fagdokumentasjoner';
 import './fellesStyling.css';
 
-// function useCvOgJobbonsker(fnr: string) {
-//     // const { data, error, isLoading } = useSWR(`/api/user/${id}`, fetcher)
-//     const { data, error, isLoading } = useSWR(fnr, hentCvOgJobbonskerv2);
-
-//     return {
-//         CvOgJobbonskerData: data,
-//         isLoading,
-//         isError: error
-//     };
-// }
-// function useUnderOppfolging(fnr: string) {
-//     // const { data, error, isLoading } = useSWR(`/api/user/${id}`, fetcher)
-//     const { data, error, isLoading } = useSWR(fnr, hentUnderOppfolging);
-
-//     return {
-//         underOppfolgingData: data,
-//         isLoadingUnderOppfolging: isLoading,
-//         ErrorUnderOppfolging: error
-//     };
-// }
-
 const CvInnhold = () => {
     const { fnr } = useAppStore();
-    // const [lasterData, setLasterData] = useState<boolean>(true);
-    // const [harFeil, setHarFeil] = useState<boolean>(false);
 
-    // const [cvOgJobbonsker, setCvOgJobbonsker] = useState<ArenaPerson | null>(null);
-    // const [underOppfolging, setUnderOppfolging] = useState<UnderOppfolgingData | null>(null);
+    const cvOgJobbonsker = useCvOgJobbonsker(fnr);
+    console.log('TEST CV:', cvOgJobbonsker.data, cvOgJobbonsker.isLoading, cvOgJobbonsker.error);
+    console.log('ERROR CV:', cvOgJobbonsker.error?.info);
 
-    // const fetcher: Fetcher<ArenaPerson, string> = (fnr) => hentCvOgJobbonskerv2(fnr);
-
-    // const { data, error, isLoading } = useSWR(fnr, hentCvOgJobbonsker);
-    // const { CvOgJobbonskerData, isLoading, isError } = useCvOgJobbonsker(fnr);
-    // console.log('TEST CV:', data, isLoading, error);
-
-    const cvOgJobbonsker = useSWR<ArenaPerson, ErrorTest>(fnr, hentCvOgJobbonsker, { shouldRetryOnError: false });
-    // console.log('TEST CV:', cvOgJobbonsker.data, cvOgJobbonsker.isLoading, cvOgJobbonsker.error?.status);
-
-    const underOppfolging = useSWR(fnr, hentUnderOppfolging);
-    // console.log('TEST OPPFØLGNING:', underOppfolging.data, underOppfolging.isLoading, underOppfolging.error);
-
-    // useEffect(() => {
-    //     const hentCvData = async () => {
-    //         try {
-    //             setLasterData(true);
-    //             const [_cvOgJobbonsker, _underOppfolging] = await Promise.all([
-    //                 hentCvOgJobbonsker(fnr),
-    //                 hentUnderOppfolging(fnr)
-    //             ]);
-
-    //             setCvOgJobbonsker(_cvOgJobbonsker);
-    //             setUnderOppfolging(_underOppfolging);
-    //         } catch (error) {
-    //             setHarFeil(true);
-    //         } finally {
-    //             setLasterData(false);
-    //         }
-    //     };
-
-    //     hentCvData();
-    // }, [fnr]);
+    const underOppfolging = useUnderOppfolging(fnr);
+    console.log('TEST OPPFØLGNING:', underOppfolging.data, underOppfolging.isLoading, underOppfolging.error);
+    console.log('ERROR OPPFØLGING:', underOppfolging.error?.info);
 
     if (cvOgJobbonsker.isLoading || underOppfolging.isLoading) {
         return (
@@ -104,7 +48,6 @@ const CvInnhold = () => {
         );
     }
 
-    // const erManuell = underOppfolging?.erManuell;
     const erManuell = underOppfolging.data?.erManuell;
 
     if (cvOgJobbonsker.data) {

--- a/src/data/api/fetch.ts
+++ b/src/data/api/fetch.ts
@@ -12,12 +12,6 @@ import { UnderOppfolgingData } from './datatyper/underOppfolgingData';
 import { AktorId } from './datatyper/aktor-id';
 import { FrontendEvent } from '../../utils/logger';
 
-export interface ErrorTest {
-    error: Error;
-    status: number;
-    info: string;
-}
-
 const handterRespons = async (respons: Response) => {
     if (respons.status === 204 || respons.status === 404 || respons.status === 403) {
         return respons.ok;
@@ -32,41 +26,6 @@ const handterRespons = async (respons: Response) => {
     } catch (error) {
         console.log('Error ved parsing:', error);
         return null;
-    }
-};
-const handterResponsv2 = async (respons: Response) => {
-    if (respons.status >= 400 && !(respons.status === 401 || respons.status === 403 || respons.status === 404)) {
-        // throw new Error(respons.statusText);
-        // const error = new Error('An error occurred while fetching the data.');
-        const errorTest: ErrorTest = {
-            error: new Error('An error occurred while fetching the data.'),
-            status: respons.status,
-            info: await respons.json()
-        };
-        throw errorTest;
-        // Attach extra info to the error object.
-        // error.info = await res.json();
-        // error.status = res.status;
-        // throw error;
-    }
-
-    if (respons.status === 204 || respons.status === 401 || respons.status === 403 || respons.status === 404) {
-        const errorTest: ErrorTest = {
-            error: new Error('An error occurred while fetching the data.'),
-            status: respons.status,
-            info: await respons.json()
-        };
-        throw errorTest;
-        // const ReturnObject: ReturnData<any> = {
-        //     value: null,
-        //     status: respons.status
-        // };
-        // return ReturnObject;
-    }
-    try {
-        return await respons.json();
-    } catch (error) {
-        throw error;
     }
 };
 
@@ -119,29 +78,9 @@ export const hentYtelser = async (fnr: string): Promise<YtelseData | null> => {
     return handterRespons(respons);
 };
 
-export const hentCvOgJobbonsker = async (fnr: string): Promise<ArenaPerson> => {
+export const hentCvOgJobbonsker = async (fnr: string): Promise<ArenaPerson | null> => {
     const url = `/veilarbperson/api/person/cv_jobbprofil?fnr=${fnr}`;
     const respons = await fetch(url, GEToptions);
-    // if (respons.status >= 400 && !(respons.status === 401 || respons.status === 403 || respons.status === 404)) {
-    //     // throw new Error(respons.statusText);
-    //     // const error = new Error('An error occurred while fetching the data.');
-    //     const error = new Error
-    //     // Attach extra info to the error object.
-    //     error.info = await respons.json();
-    //     error.status = respons.status;
-    //     throw error;
-    // }
-    // return respons.json();
-
-    return handterResponsv2(respons);
-};
-
-export const hentCvOgJobbonskerv2 = async (fnr: string): Promise<ArenaPerson | null> => {
-    const url = `/veilarbperson/api/person/cv_jobbprofil?fnr=${fnr}`;
-    const respons = await fetch(url, GEToptions);
-    // const data = await respons.json();
-    // return data;
-    // return fetch(url, GEToptions).then((r) => r.json());
 
     return handterRespons(respons);
 };

--- a/src/data/api/fetch.ts
+++ b/src/data/api/fetch.ts
@@ -12,6 +12,12 @@ import { UnderOppfolgingData } from './datatyper/underOppfolgingData';
 import { AktorId } from './datatyper/aktor-id';
 import { FrontendEvent } from '../../utils/logger';
 
+export interface ErrorTest {
+    error: Error;
+    status: number;
+    info: string;
+}
+
 const handterRespons = async (respons: Response) => {
     if (respons.status === 204 || respons.status === 404 || respons.status === 403) {
         return respons.ok;
@@ -26,6 +32,41 @@ const handterRespons = async (respons: Response) => {
     } catch (error) {
         console.log('Error ved parsing:', error);
         return null;
+    }
+};
+const handterResponsv2 = async (respons: Response) => {
+    if (respons.status >= 400 && !(respons.status === 401 || respons.status === 403 || respons.status === 404)) {
+        // throw new Error(respons.statusText);
+        // const error = new Error('An error occurred while fetching the data.');
+        const errorTest: ErrorTest = {
+            error: new Error('An error occurred while fetching the data.'),
+            status: respons.status,
+            info: await respons.json()
+        };
+        throw errorTest;
+        // Attach extra info to the error object.
+        // error.info = await res.json();
+        // error.status = res.status;
+        // throw error;
+    }
+
+    if (respons.status === 204 || respons.status === 401 || respons.status === 403 || respons.status === 404) {
+        const errorTest: ErrorTest = {
+            error: new Error('An error occurred while fetching the data.'),
+            status: respons.status,
+            info: await respons.json()
+        };
+        throw errorTest;
+        // const ReturnObject: ReturnData<any> = {
+        //     value: null,
+        //     status: respons.status
+        // };
+        // return ReturnObject;
+    }
+    try {
+        return await respons.json();
+    } catch (error) {
+        throw error;
     }
 };
 
@@ -78,9 +119,29 @@ export const hentYtelser = async (fnr: string): Promise<YtelseData | null> => {
     return handterRespons(respons);
 };
 
-export const hentCvOgJobbonsker = async (fnr: string): Promise<ArenaPerson | null> => {
+export const hentCvOgJobbonsker = async (fnr: string): Promise<ArenaPerson> => {
     const url = `/veilarbperson/api/person/cv_jobbprofil?fnr=${fnr}`;
     const respons = await fetch(url, GEToptions);
+    // if (respons.status >= 400 && !(respons.status === 401 || respons.status === 403 || respons.status === 404)) {
+    //     // throw new Error(respons.statusText);
+    //     // const error = new Error('An error occurred while fetching the data.');
+    //     const error = new Error
+    //     // Attach extra info to the error object.
+    //     error.info = await respons.json();
+    //     error.status = respons.status;
+    //     throw error;
+    // }
+    // return respons.json();
+
+    return handterResponsv2(respons);
+};
+
+export const hentCvOgJobbonskerv2 = async (fnr: string): Promise<ArenaPerson | null> => {
+    const url = `/veilarbperson/api/person/cv_jobbprofil?fnr=${fnr}`;
+    const respons = await fetch(url, GEToptions);
+    // const data = await respons.json();
+    // return data;
+    // return fetch(url, GEToptions).then((r) => r.json());
 
     return handterRespons(respons);
 };

--- a/src/data/api/fetchv2.ts
+++ b/src/data/api/fetchv2.ts
@@ -30,6 +30,14 @@ const handterRespons = async (respons: Response) => {
         };
         throw error;
     }
+    if (respons.status === 204) {
+        const error: ErrorMessage = {
+            error: new Error('No content'),
+            status: respons.status,
+            info: null
+        };
+        throw error;
+    }
 
     try {
         return await respons.json();

--- a/src/data/api/fetchv2.ts
+++ b/src/data/api/fetchv2.ts
@@ -15,35 +15,30 @@ import useSWR from 'swr';
 
 // FÅ PÅ SWR-CONFIG, IKKE FLERE RETRIES ETTER ERROR!
 
-export interface ErrorTest {
-    error: Error;
-    status: number;
+interface ErrorMessage {
+    error: Error | unknown;
+    status?: number | null;
     info: StringOrNothing;
 }
 
 const handterRespons = async (respons: Response) => {
-    // if (respons.status >= 400 && !(respons.status === 401 || respons.status === 403 || respons.status === 404)) {
     if (respons.status >= 400) {
-        const errorTest: ErrorTest = {
+        const error: ErrorMessage = {
             error: new Error('An error occurred while fetching the data.'),
             status: respons.status,
             info: await respons.json()
         };
-        throw errorTest;
+        throw error;
     }
-
-    // if (respons.status === 204 || respons.status === 401 || respons.status === 403 || respons.status === 404) {
-    //     const errorTest: ErrorTest = {
-    //         error: new Error('An error occurred while fetching the data.'),
-    //         status: respons.status,
-    //         info: await respons.json()
-    //     };
-    //     throw errorTest;
-    // }
 
     try {
         return await respons.json();
-    } catch (error) {
+    } catch (err) {
+        const error: ErrorMessage = {
+            error: err,
+            status: null,
+            info: null
+        };
         throw error;
     }
 };
@@ -62,7 +57,7 @@ export const sendEventTilVeilarbperson = async (event: FrontendEvent): Promise<a
 };
 
 export const useCvOgJobbonsker = (fnr: string) => {
-    const { data, error, isLoading } = useSWR<ArenaPerson>(
+    const { data, error, isLoading } = useSWR<ArenaPerson, ErrorMessage>(
         `/veilarbperson/api/person/cv_jobbprofil?fnr=${fnr}`,
         fetcher
     );
@@ -71,7 +66,7 @@ export const useCvOgJobbonsker = (fnr: string) => {
 };
 
 export const useUnderOppfolging = (fnr: string) => {
-    const { data, error, isLoading } = useSWR<UnderOppfolgingData>(
+    const { data, error, isLoading } = useSWR<UnderOppfolgingData, ErrorMessage>(
         `/veilarboppfolging/api/underoppfolging?fnr=${fnr}`,
         fetcher
     );
@@ -80,7 +75,7 @@ export const useUnderOppfolging = (fnr: string) => {
 };
 
 export const useOppfolgingsstatus = (fnr: string) => {
-    const { data, error, isLoading } = useSWR<OppfolgingsstatusData>(
+    const { data, error, isLoading } = useSWR<OppfolgingsstatusData, ErrorMessage>(
         `/veilarboppfolging/api/person/${fnr}/oppfolgingsstatus`,
         fetcher
     );
@@ -89,13 +84,16 @@ export const useOppfolgingsstatus = (fnr: string) => {
 };
 
 export const usePersonalia = (fnr: string) => {
-    const { data, error, isLoading } = useSWR<PersonaliaV2Info>(`/veilarbperson/api/v2/person?fnr=${fnr}`, fetcher);
+    const { data, error, isLoading } = useSWR<PersonaliaV2Info, ErrorMessage>(
+        `/veilarbperson/api/v2/person?fnr=${fnr}`,
+        fetcher
+    );
 
     return { data, isLoading, error };
 };
 
 export const useRegistrering = (fnr: string) => {
-    const { data, error, isLoading } = useSWR<RegistreringsData>(
+    const { data, error, isLoading } = useSWR<RegistreringsData, ErrorMessage>(
         `/veilarbperson/api/person/registrering?fnr=${fnr}`,
         fetcher
     );
@@ -104,7 +102,7 @@ export const useRegistrering = (fnr: string) => {
 };
 
 export const useTolk = (fnr: string) => {
-    const { data, error, isLoading } = useSWR<TilrettelagtKommunikasjonData>(
+    const { data, error, isLoading } = useSWR<TilrettelagtKommunikasjonData, ErrorMessage>(
         `/veilarbperson/api/v2/person/tolk?fnr=${fnr}`,
         fetcher
     );
@@ -113,7 +111,7 @@ export const useTolk = (fnr: string) => {
 };
 
 export const useVergeOgFullmakt = (fnr: string) => {
-    const { data, error, isLoading } = useSWR<VergeOgFullmaktData>(
+    const { data, error, isLoading } = useSWR<VergeOgFullmaktData, ErrorMessage>(
         `/veilarbperson/api/v2/person/vergeOgFullmakt?fnr=${fnr}`,
         fetcher
     );
@@ -122,19 +120,28 @@ export const useVergeOgFullmakt = (fnr: string) => {
 };
 
 export const useYtelser = (fnr: string) => {
-    const { data, error, isLoading } = useSWR<YtelseData>(`/veilarboppfolging/api/person/${fnr}/ytelser`, fetcher);
+    const { data, error, isLoading } = useSWR<YtelseData, ErrorMessage>(
+        `/veilarboppfolging/api/person/${fnr}/ytelser`,
+        fetcher
+    );
 
     return { data, isLoading, error };
 };
 
 export const useAktorId = (fnr: string) => {
-    const { data, error, isLoading } = useSWR<AktorId>(`/veilarbperson/api/person/aktorid?fnr=${fnr}`, fetcher);
+    const { data, error, isLoading } = useSWR<AktorId, ErrorMessage>(
+        `/veilarbperson/api/person/aktorid?fnr=${fnr}`,
+        fetcher
+    );
 
     return { data, isLoading, error };
 };
 
 export const useVeileder = (veilederId: string) => {
-    const { data, error, isLoading } = useSWR<VeilederData>(`/veilarbveileder/api/veileder/${veilederId}`, fetcher);
+    const { data, error, isLoading } = useSWR<VeilederData, ErrorMessage>(
+        `/veilarbveileder/api/veileder/${veilederId}`,
+        fetcher
+    );
 
     return { data, isLoading, error };
 };

--- a/src/data/api/fetchv2.ts
+++ b/src/data/api/fetchv2.ts
@@ -13,8 +13,6 @@ import { AktorId } from './datatyper/aktor-id';
 import { FrontendEvent } from '../../utils/logger';
 import useSWR from 'swr';
 
-// FÅ PÅ SWR-CONFIG, IKKE FLERE RETRIES ETTER ERROR!
-
 interface ErrorMessage {
     error: Error | unknown;
     status?: number | null;
@@ -67,7 +65,8 @@ export const sendEventTilVeilarbperson = async (event: FrontendEvent): Promise<a
 export const useCvOgJobbonsker = (fnr: string) => {
     const { data, error, isLoading } = useSWR<ArenaPerson, ErrorMessage>(
         `/veilarbperson/api/person/cv_jobbprofil?fnr=${fnr}`,
-        fetcher
+        fetcher,
+        { shouldRetryOnError: false, revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
     );
 
     return { data, isLoading, error };
@@ -76,7 +75,8 @@ export const useCvOgJobbonsker = (fnr: string) => {
 export const useUnderOppfolging = (fnr: string) => {
     const { data, error, isLoading } = useSWR<UnderOppfolgingData, ErrorMessage>(
         `/veilarboppfolging/api/underoppfolging?fnr=${fnr}`,
-        fetcher
+        fetcher,
+        { shouldRetryOnError: false, revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
     );
 
     return { data, isLoading, error };
@@ -85,7 +85,8 @@ export const useUnderOppfolging = (fnr: string) => {
 export const useOppfolgingsstatus = (fnr: string) => {
     const { data, error, isLoading } = useSWR<OppfolgingsstatusData, ErrorMessage>(
         `/veilarboppfolging/api/person/${fnr}/oppfolgingsstatus`,
-        fetcher
+        fetcher,
+        { shouldRetryOnError: false, revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
     );
 
     return { data, isLoading, error };
@@ -94,7 +95,8 @@ export const useOppfolgingsstatus = (fnr: string) => {
 export const usePersonalia = (fnr: string) => {
     const { data, error, isLoading } = useSWR<PersonaliaV2Info, ErrorMessage>(
         `/veilarbperson/api/v2/person?fnr=${fnr}`,
-        fetcher
+        fetcher,
+        { shouldRetryOnError: false, revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
     );
 
     return { data, isLoading, error };
@@ -103,7 +105,8 @@ export const usePersonalia = (fnr: string) => {
 export const useRegistrering = (fnr: string) => {
     const { data, error, isLoading } = useSWR<RegistreringsData, ErrorMessage>(
         `/veilarbperson/api/person/registrering?fnr=${fnr}`,
-        fetcher
+        fetcher,
+        { shouldRetryOnError: false, revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
     );
 
     return { data, isLoading, error };
@@ -112,7 +115,8 @@ export const useRegistrering = (fnr: string) => {
 export const useTolk = (fnr: string) => {
     const { data, error, isLoading } = useSWR<TilrettelagtKommunikasjonData, ErrorMessage>(
         `/veilarbperson/api/v2/person/tolk?fnr=${fnr}`,
-        fetcher
+        fetcher,
+        { shouldRetryOnError: false, revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
     );
 
     return { data, isLoading, error };
@@ -121,7 +125,8 @@ export const useTolk = (fnr: string) => {
 export const useVergeOgFullmakt = (fnr: string) => {
     const { data, error, isLoading } = useSWR<VergeOgFullmaktData, ErrorMessage>(
         `/veilarbperson/api/v2/person/vergeOgFullmakt?fnr=${fnr}`,
-        fetcher
+        fetcher,
+        { shouldRetryOnError: false, revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
     );
 
     return { data, isLoading, error };
@@ -130,7 +135,8 @@ export const useVergeOgFullmakt = (fnr: string) => {
 export const useYtelser = (fnr: string) => {
     const { data, error, isLoading } = useSWR<YtelseData, ErrorMessage>(
         `/veilarboppfolging/api/person/${fnr}/ytelser`,
-        fetcher
+        fetcher,
+        { shouldRetryOnError: false, revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
     );
 
     return { data, isLoading, error };
@@ -139,7 +145,8 @@ export const useYtelser = (fnr: string) => {
 export const useAktorId = (fnr: string) => {
     const { data, error, isLoading } = useSWR<AktorId, ErrorMessage>(
         `/veilarbperson/api/person/aktorid?fnr=${fnr}`,
-        fetcher
+        fetcher,
+        { shouldRetryOnError: false, revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
     );
 
     return { data, isLoading, error };
@@ -148,7 +155,8 @@ export const useAktorId = (fnr: string) => {
 export const useVeileder = (veilederId: string) => {
     const { data, error, isLoading } = useSWR<VeilederData, ErrorMessage>(
         `/veilarbveileder/api/veileder/${veilederId}`,
-        fetcher
+        fetcher,
+        { shouldRetryOnError: false, revalidateIfStale: false, revalidateOnFocus: false, revalidateOnReconnect: false }
     );
 
     return { data, isLoading, error };

--- a/src/data/api/fetchv2.ts
+++ b/src/data/api/fetchv2.ts
@@ -1,0 +1,140 @@
+import { GEToptions, createPOSToptions } from './datatyper/apiOptions';
+import { OppfolgingsstatusData } from './datatyper/oppfolgingsstatus';
+import { PersonaliaV2Info } from './datatyper/personalia';
+import { RegistreringsData } from './datatyper/registreringsData';
+import { TilrettelagtKommunikasjonData } from './datatyper/tilrettelagtKommunikasjon';
+import { StringOrNothing } from '../../utils/felles-typer';
+import { VeilederData } from './datatyper/veileder';
+import { YtelseData } from './datatyper/ytelse';
+import { VergeOgFullmaktData } from './datatyper/vergeOgFullmakt';
+import { ArenaPerson } from './datatyper/arenaperson';
+import { UnderOppfolgingData } from './datatyper/underOppfolgingData';
+import { AktorId } from './datatyper/aktor-id';
+import { FrontendEvent } from '../../utils/logger';
+import useSWR from 'swr';
+
+// FÅ PÅ SWR-CONFIG, IKKE FLERE RETRIES ETTER ERROR!
+
+export interface ErrorTest {
+    error: Error;
+    status: number;
+    info: StringOrNothing;
+}
+
+const handterRespons = async (respons: Response) => {
+    // if (respons.status >= 400 && !(respons.status === 401 || respons.status === 403 || respons.status === 404)) {
+    if (respons.status >= 400) {
+        const errorTest: ErrorTest = {
+            error: new Error('An error occurred while fetching the data.'),
+            status: respons.status,
+            info: await respons.json()
+        };
+        throw errorTest;
+    }
+
+    // if (respons.status === 204 || respons.status === 401 || respons.status === 403 || respons.status === 404) {
+    //     const errorTest: ErrorTest = {
+    //         error: new Error('An error occurred while fetching the data.'),
+    //         status: respons.status,
+    //         info: await respons.json()
+    //     };
+    //     throw errorTest;
+    // }
+
+    try {
+        return await respons.json();
+    } catch (error) {
+        throw error;
+    }
+};
+
+const fetcher = async (url: string): Promise<any> => {
+    const respons = await fetch(url, GEToptions);
+
+    return handterRespons(respons);
+};
+
+export const sendEventTilVeilarbperson = async (event: FrontendEvent): Promise<any> => {
+    const url = `/veilarbperson/api/logger/event`;
+    const respons = await fetch(url, createPOSToptions(event));
+
+    return handterRespons(respons);
+};
+
+export const useCvOgJobbonsker = (fnr: string) => {
+    const { data, error, isLoading } = useSWR<ArenaPerson>(
+        `/veilarbperson/api/person/cv_jobbprofil?fnr=${fnr}`,
+        fetcher
+    );
+
+    return { data, isLoading, error };
+};
+
+export const useUnderOppfolging = (fnr: string) => {
+    const { data, error, isLoading } = useSWR<UnderOppfolgingData>(
+        `/veilarboppfolging/api/underoppfolging?fnr=${fnr}`,
+        fetcher
+    );
+
+    return { data, isLoading, error };
+};
+
+export const useOppfolgingsstatus = (fnr: string) => {
+    const { data, error, isLoading } = useSWR<OppfolgingsstatusData>(
+        `/veilarboppfolging/api/person/${fnr}/oppfolgingsstatus`,
+        fetcher
+    );
+
+    return { data, isLoading, error };
+};
+
+export const usePersonalia = (fnr: string) => {
+    const { data, error, isLoading } = useSWR<PersonaliaV2Info>(`/veilarbperson/api/v2/person?fnr=${fnr}`, fetcher);
+
+    return { data, isLoading, error };
+};
+
+export const useRegistrering = (fnr: string) => {
+    const { data, error, isLoading } = useSWR<RegistreringsData>(
+        `/veilarbperson/api/person/registrering?fnr=${fnr}`,
+        fetcher
+    );
+
+    return { data, isLoading, error };
+};
+
+export const useTolk = (fnr: string) => {
+    const { data, error, isLoading } = useSWR<TilrettelagtKommunikasjonData>(
+        `/veilarbperson/api/v2/person/tolk?fnr=${fnr}`,
+        fetcher
+    );
+
+    return { data, isLoading, error };
+};
+
+export const useVergeOgFullmakt = (fnr: string) => {
+    const { data, error, isLoading } = useSWR<VergeOgFullmaktData>(
+        `/veilarbperson/api/v2/person/vergeOgFullmakt?fnr=${fnr}`,
+        fetcher
+    );
+
+    return { data, isLoading, error };
+};
+
+export const useYtelser = (fnr: string) => {
+    const { data, error, isLoading } = useSWR<YtelseData>(`/veilarboppfolging/api/person/${fnr}/ytelser`, fetcher);
+
+    return { data, isLoading, error };
+};
+
+export const useAktorId = (fnr: string) => {
+    const { data, error, isLoading } = useSWR<AktorId>(`/veilarbperson/api/person/aktorid?fnr=${fnr}`, fetcher);
+
+    return { data, isLoading, error };
+};
+
+export const useVeileder = (veilederId: string) => {
+    const { data, error, isLoading } = useSWR<VeilederData>(`/veilarbveileder/api/veileder/${veilederId}`, fetcher);
+
+    return { data, isLoading, error };
+};


### PR DESCRIPTION
Implementert datahenting ved bruk av SWR:
> - Datahenting skjer ved bruk av SWR-hooks, som ligger i fetchv2.ts
> - Kan kalle på de forskjellige endepunktene som treng i de forskjellige komponentene direkte, men vil fortsatt kun sende 1 request. Slipper dermed å sende data som props gjennom komponenter og unngår "waterfall" effekt på api-kall siden SWR sender requests parallelt.
> - Error håndtering er enklere da alle HTTP status koder sendes med I error-meldingen, som kan sjekkes i komponentene

Lagt til enkel feilhåndtering for CV basert på HTTP-statuskoder dersom CV ikke er registrert eller at veileder ikke har tilgang til CVen.

Datahenting ved bruk av SWR-hooks er kun implementert for CV-komponenten, resten av komponentene bruker den gamle løsningen, men er raskt å endre siden alle de forskjellige api-kallene er implementert i fetchv2.ts