### PR TITLE
Fikse profileringsboks

### DIFF
--- a/src/components/cv-innhold.tsx
+++ b/src/components/cv-innhold.tsx
@@ -102,7 +102,6 @@ const Cvinnhold = () => {
                     <RedigerCV erManuell={erManuell} endreCvUrl={endreCvUrl} />
                 </HStack>
                 <SistEndret sistEndret={sistEndret} onlyYearAndMonth={false} />
-                <CvIkkeSynligInfo />
                 <Sammendrag sammendrag={sammendrag} />
                 <div className="info_container">
                     <Utdanning utdanning={utdanning} />
@@ -116,6 +115,7 @@ const Cvinnhold = () => {
                     <Godkjenninger godkjenninger={godkjenninger} />
                     <AndreGodkjenninger andreGodkjenninger={andreGodkjenninger} />
                 </div>
+                <CvIkkeSynligInfo />
             </>
         );
     }

--- a/src/components/cv/cv-ikke-synlig-info.tsx
+++ b/src/components/cv/cv-ikke-synlig-info.tsx
@@ -1,14 +1,17 @@
-import { Alert, Link } from '@navikt/ds-react';
+import { Alert, BodyShort, Link } from '@navikt/ds-react';
 
 export const CvIkkeSynligInfo = () => {
     return (
         <Alert variant="info" className="cv_ikke_synlig">
-            Fra 17.2.2021 kan arbeidsgivere kun se CV til jobbsøkere som ikke er under arbeidsrettet oppfølging fra NAV.
-            Les mer om{' '}
-            <Link href="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-markedsarbeid/SitePages/Oversikt-over-veileders-tilgang-p%C3%A5-CV-og-jobbprofil.aspx">
-                synlig CV
-            </Link>
-            .
+            <BodyShort size="small">
+                {' '}
+                Fra 17.2.2021 kan arbeidsgivere kun se CV til jobbsøkere som ikke er under arbeidsrettet oppfølging fra
+                NAV. Les mer om{' '}
+                <Link href="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-markedsarbeid/SitePages/Oversikt-over-veileders-tilgang-p%C3%A5-CV-og-jobbprofil.aspx">
+                    synlig CV
+                </Link>
+                .{' '}
+            </BodyShort>
         </Alert>
     );
 };

--- a/src/components/cv/sammendrag.tsx
+++ b/src/components/cv/sammendrag.tsx
@@ -11,7 +11,9 @@ const Sammendrag = ({ sammendrag }: Pick<ArenaPerson, 'sammendrag'>) => {
             icon={<BulletListIcon title="Ikon som illustrerer en punktliste" aria-hidden="true" />}
             headerTypo="ingress"
         >
-            <BodyShort className="underinformasjon">{sammendrag ? sammendrag : EMDASH}</BodyShort>
+            <BodyShort className="underinformasjon" size="small">
+                {sammendrag ? sammendrag : EMDASH}
+            </BodyShort>
         </Informasjonsbolk>
     );
 };

--- a/src/components/registrering/foreslatt-profilering.tsx
+++ b/src/components/registrering/foreslatt-profilering.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, Ingress, Panel } from '@navikt/ds-react';
+import { BodyShort, Heading, Panel } from '@navikt/ds-react';
 import { OrdinaerRegistrering, Registrering } from '../../data/api/datatyper/registreringsData';
 import './registrering.css';
 import { innsatsgruppeBeskrivelse } from '../../utils/text-mapper';
@@ -20,8 +20,13 @@ export function ForeslattProfilering(props: Props) {
 
     return (
         <Panel border className="profilering_boks">
-            <Ingress>Forslag om brukers muligheter og behov (resultat fra profilering)</Ingress>
-            <BodyShort>{innsatsgruppeBeskrivelse(ordinaerRegistrering.profilering.innsatsgruppe)}</BodyShort>
+            <Heading level="4" size="small">
+                Forslag om brukers muligheter og behov (resultat fra profilering)
+            </Heading>
+            <BodyShort size="small">
+                {' '}
+                {innsatsgruppeBeskrivelse(ordinaerRegistrering.profilering.innsatsgruppe)}
+            </BodyShort>
         </Panel>
     );
 }

--- a/src/utils/text-mapper.ts
+++ b/src/utils/text-mapper.ts
@@ -51,11 +51,11 @@ export function mapHovedmalTilTekst(hovedmal: OrNothing<Hovedmal | ArenaHovedmal
 export function innsatsgruppeBeskrivelse(innsatsgruppe: InnsatsgruppeType) {
     switch (innsatsgruppe) {
         case 'STANDARD_INNSATS':
-            return 'Antatt rask overgang til arbeid: Vurdér om brukeren har gode muligheter til å beholde eller komme i jobb på egenhånd.';
+            return 'Antatt rask overgang til arbeid: Vurder om brukeren har gode muligheter til å beholde eller komme i jobb på egenhånd.';
         case 'SITUASJONSBESTEMT_INNSATS':
-            return 'Antatt behov for veiledning: Vurdér brukerens jobbmuligheter og behov for veiledning.';
+            return 'Antatt behov for veiledning: Vurder brukerens jobbmuligheter og behov for veiledning.';
         case 'BEHOV_FOR_ARBEIDSEVNEVURDERING':
-            return 'Brukeren har oppgitt hindringer: Vurdér brukerens jobbmuligheter og behov for veiledning.';
+            return 'Brukeren har oppgitt hindringer: Vurder brukerens jobbmuligheter og behov for veiledning.';
         default:
             return '';
     }
@@ -81,6 +81,7 @@ export function mapInnsatsgruppeTilTekst(innsatsgruppe: OrNothing<Innsatsgruppe 
             return EMDASH;
     }
 }
+
 export function hentOppfolgingsEnhetTekst(
     oppfolgingsstatus: OppfolgingsstatusData | null | undefined
 ): StringOrNothing {


### PR DESCRIPTION
Summa summarum: Se på CV-endringene, det med profileringsboksen må vi diskutere mer med Kari

Det havnet egentlig to ting i denne PRen nå. Det ene er det med infoboksen i profilering, det andre er at jeg og Kari ble enige om å gjøre sammendraget i CVen til small samt å flytte infoboksen til CV nederst i kortet.
![image](https://github.com/navikt/veilarbdetaljerfs/assets/34374522/48f7a203-d074-4064-9d98-b5cf2d4d61ce)
![image](https://github.com/navikt/veilarbdetaljerfs/assets/34374522/99f6fe2b-0043-471b-8626-c72450af265f)
![image](https://github.com/navikt/veilarbdetaljerfs/assets/34374522/aa635a03-6e64-4246-b2bc-46575643d72a)

