### PR TITLE
Tilpasse nokkelinfoboksen

### DIFF
--- a/src/components/felles/enkeltInfo.tsx
+++ b/src/components/felles/enkeltInfo.tsx
@@ -1,21 +1,29 @@
 import EMDASH from '../../utils/emdash';
 import { StringOrNothing } from '../../utils/felles-typer';
-import { BodyShort } from '@navikt/ds-react';
+import {Alert, BodyShort} from '@navikt/ds-react';
 
 interface Props {
     header: string;
     value?: StringOrNothing;
+    error?: StringOrNothing;
 }
 
-export function EnkeltInformasjon({ header, value = EMDASH }: Props) {
+export function EnkeltInformasjon({ header, value = EMDASH, error }: Props) {
     return (
         <span>
             <BodyShort size="small" className="body_header">
                 {header}
             </BodyShort>
+            {!error &&
             <BodyShort size="small" className="enkeltinfo_value">
                 {value}
             </BodyShort>
+            }
+            {error &&
+            <Alert variant="error" inline size="small" >
+                {error}
+            </Alert>
+            }
         </span>
     );
 }

--- a/src/components/felles/enkeltInfo.tsx
+++ b/src/components/felles/enkeltInfo.tsx
@@ -20,7 +20,7 @@ export function EnkeltInformasjon({ header, value = EMDASH, error }: Props) {
             </BodyShort>
             }
             {error &&
-            <Alert variant="error" inline size="small" >
+            <Alert variant="info" inline size="small" >
                 {error}
             </Alert>
             }

--- a/src/components/felles/enkeltInfo.tsx
+++ b/src/components/felles/enkeltInfo.tsx
@@ -5,23 +5,23 @@ import { Alert, BodyShort } from '@navikt/ds-react';
 interface Props {
     header: string;
     value?: StringOrNothing;
-    error?: StringOrNothing;
+    errorMessage?: StringOrNothing;
 }
 
-export function EnkeltInformasjon({ header, value = EMDASH, error }: Props) {
+export function EnkeltInformasjon({ header, value = EMDASH, errorMessage }: Props) {
     return (
         <span>
             <BodyShort size="small" className="body_header">
                 {header}
             </BodyShort>
-            {!error && (
+            {!errorMessage && (
                 <BodyShort size="small" className="enkeltinfo_value">
                     {value}
                 </BodyShort>
             )}
-            {error && (
+            {errorMessage && (
                 <Alert variant="info" inline size="small">
-                    {error}
+                    {errorMessage}
                 </Alert>
             )}
         </span>

--- a/src/components/felles/enkeltInfo.tsx
+++ b/src/components/felles/enkeltInfo.tsx
@@ -1,6 +1,6 @@
 import EMDASH from '../../utils/emdash';
 import { StringOrNothing } from '../../utils/felles-typer';
-import {Alert, BodyShort} from '@navikt/ds-react';
+import { Alert, BodyShort } from '@navikt/ds-react';
 
 interface Props {
     header: string;
@@ -14,16 +14,16 @@ export function EnkeltInformasjon({ header, value = EMDASH, error }: Props) {
             <BodyShort size="small" className="body_header">
                 {header}
             </BodyShort>
-            {!error &&
-            <BodyShort size="small" className="enkeltinfo_value">
-                {value}
-            </BodyShort>
-            }
-            {error &&
-            <Alert variant="info" inline size="small" >
-                {error}
-            </Alert>
-            }
+            {!error && (
+                <BodyShort size="small" className="enkeltinfo_value">
+                    {value}
+                </BodyShort>
+            )}
+            {error && (
+                <Alert variant="info" inline size="small">
+                    {error}
+                </Alert>
+            )}
         </span>
     );
 }

--- a/src/components/nokkelinfo.tsx
+++ b/src/components/nokkelinfo.tsx
@@ -88,7 +88,7 @@ const Nokkelinfo = () => {
         registreringError ||
         tolkError ||
         ytelserError ||
-        cvOgJobbonskerError ||
+        // cvOgJobbonskerError ||
         veilederError
     ) {
         return (
@@ -122,6 +122,10 @@ const Nokkelinfo = () => {
             ? barnUnder21.map((barn) => `${barn.fornavn} (${kalkulerAlder(new Date(barn.fodselsdato))})`).join(', ')
             : EMDASH;
 
+
+    const cvErrorBlaBla: StringOrNothing = cvOgJobbonskerError?.status ? cvOgJobbonskerError.status.toString() : null;
+
+
     return (
         <Panel border className="nokkelinfo_panel">
             <Heading spacing level="2" size="medium">
@@ -135,7 +139,7 @@ const Nokkelinfo = () => {
                 <EnkeltInformasjon header="Veileder" value={hentVeilederTekst(veilederData)} />
                 <EnkeltInformasjon header="Tilrettelagt kommunikasjon" value={hentTolkTekst(taletolk)} />
                 <EnkeltInformasjon header="Sivilstand" value={formatStringInUpperAndLowerCaseUnderscore(sivilstatus)} />
-                <EnkeltInformasjon header="Jobbønsker" value={jobbonsker} />
+                <EnkeltInformasjon header="Jobbønsker" value={jobbonsker} error={cvErrorBlaBla} />
                 <EnkeltInformasjon header="Registrert av" value={registrertAv} />
                 <EnkeltInformasjon header="Aktive ytelse(r)" value={getVedtakForVisning(ytelserData?.vedtaksliste)} />
             </span>

--- a/src/components/nokkelinfo.tsx
+++ b/src/components/nokkelinfo.tsx
@@ -128,7 +128,7 @@ const Nokkelinfoinnhold = () => {
             <EnkeltInformasjon
                 header="Jobbønsker"
                 value={jobbonsker}
-                error={mapErrorCvOgJobbonsker(cvOgJobbonskerError?.status)}
+                errorMessage={mapErrorCvOgJobbonsker(cvOgJobbonskerError?.status)}
             />
             <EnkeltInformasjon header="Registrert av" value={registrertAv} />
             <EnkeltInformasjon header="Aktive ytelse(r)" value={getVedtakForVisning(ytelserData?.vedtaksliste)} />

--- a/src/components/nokkelinfo.tsx
+++ b/src/components/nokkelinfo.tsx
@@ -88,7 +88,6 @@ const Nokkelinfo = () => {
         registreringError ||
         tolkError ||
         ytelserError ||
-        // cvOgJobbonskerError ||
         veilederError
     ) {
         return (
@@ -122,16 +121,14 @@ const Nokkelinfo = () => {
             ? barnUnder21.map((barn) => `${barn.fornavn} (${kalkulerAlder(new Date(barn.fodselsdato))})`).join(', ')
             : EMDASH;
 
-
-    const mapErrorCvOgJobbonsker = (errorStatus: number | null | undefined ): StringOrNothing => {
+    const mapErrorCvOgJobbonsker = (errorStatus: number | null | undefined): StringOrNothing => {
         switch (errorStatus) {
             case 403:
-                return "Du har ikke tilgang. Mer informasjon i jobbønsker-boksen.";
+                return 'Du har ikke tilgang. Mer informasjon i jobbønsker-boksen.';
             default:
                 return null;
         }
     };
-
 
     return (
         <Panel border className="nokkelinfo_panel">
@@ -146,7 +143,11 @@ const Nokkelinfo = () => {
                 <EnkeltInformasjon header="Veileder" value={hentVeilederTekst(veilederData)} />
                 <EnkeltInformasjon header="Tilrettelagt kommunikasjon" value={hentTolkTekst(taletolk)} />
                 <EnkeltInformasjon header="Sivilstand" value={formatStringInUpperAndLowerCaseUnderscore(sivilstatus)} />
-                <EnkeltInformasjon header="Jobbønsker" value={jobbonsker} error={mapErrorCvOgJobbonsker(cvOgJobbonskerError?.status)} />
+                <EnkeltInformasjon
+                    header="Jobbønsker"
+                    value={jobbonsker}
+                    error={mapErrorCvOgJobbonsker(cvOgJobbonskerError?.status)}
+                />
                 <EnkeltInformasjon header="Registrert av" value={registrertAv} />
                 <EnkeltInformasjon header="Aktive ytelse(r)" value={getVedtakForVisning(ytelserData?.vedtaksliste)} />
             </span>

--- a/src/components/nokkelinfo.tsx
+++ b/src/components/nokkelinfo.tsx
@@ -123,7 +123,14 @@ const Nokkelinfo = () => {
             : EMDASH;
 
 
-    const cvErrorBlaBla: StringOrNothing = cvOgJobbonskerError?.status ? cvOgJobbonskerError.status.toString() : null;
+    const mapErrorCvOgJobbonsker = (errorStatus: number | null | undefined ): StringOrNothing => {
+        switch (errorStatus) {
+            case 403:
+                return "Du har ikke tilgang. Mer informasjon i jobbønsker-boksen.";
+            default:
+                return null;
+        }
+    };
 
 
     return (
@@ -139,7 +146,7 @@ const Nokkelinfo = () => {
                 <EnkeltInformasjon header="Veileder" value={hentVeilederTekst(veilederData)} />
                 <EnkeltInformasjon header="Tilrettelagt kommunikasjon" value={hentTolkTekst(taletolk)} />
                 <EnkeltInformasjon header="Sivilstand" value={formatStringInUpperAndLowerCaseUnderscore(sivilstatus)} />
-                <EnkeltInformasjon header="Jobbønsker" value={jobbonsker} error={cvErrorBlaBla} />
+                <EnkeltInformasjon header="Jobbønsker" value={jobbonsker} error={mapErrorCvOgJobbonsker(cvOgJobbonskerError?.status)} />
                 <EnkeltInformasjon header="Registrert av" value={registrertAv} />
                 <EnkeltInformasjon header="Aktive ytelse(r)" value={getVedtakForVisning(ytelserData?.vedtaksliste)} />
             </span>

--- a/src/components/nokkelinfo.tsx
+++ b/src/components/nokkelinfo.tsx
@@ -125,7 +125,11 @@ const Nokkelinfoinnhold = () => {
             <EnkeltInformasjon header="Veileder" value={hentVeilederTekst(veilederData)} />
             <EnkeltInformasjon header="Tilrettelagt kommunikasjon" value={hentTolkTekst(taletolk)} />
             <EnkeltInformasjon header="Sivilstand" value={formatStringInUpperAndLowerCaseUnderscore(sivilstatus)} />
-            <EnkeltInformasjon header="Jobbønsker" value={jobbonsker} error={mapErrorCvOgJobbonsker(cvOgJobbonskerError?.status)} />
+            <EnkeltInformasjon
+                header="Jobbønsker"
+                value={jobbonsker}
+                error={mapErrorCvOgJobbonsker(cvOgJobbonskerError?.status)}
+            />
             <EnkeltInformasjon header="Registrert av" value={registrertAv} />
             <EnkeltInformasjon header="Aktive ytelse(r)" value={getVedtakForVisning(ytelserData?.vedtaksliste)} />
         </span>

--- a/src/data/mock/api/veilarbperson.ts
+++ b/src/data/mock/api/veilarbperson.ts
@@ -676,7 +676,7 @@ const sykmeldtRegistering: RegistreringsData = {
 
 export const veilarbpersonHandlers: RequestHandler[] = [
     rest.get('/veilarbperson/api/person/cv_jobbprofil', (_, res, ctx) => {
-        return res(ctx.delay(500), ctx.json(cvOgJobbonsker));
+        return res(ctx.status(403));
     }),
     rest.get('/veilarbperson/api/person/aktorid', (_, res, ctx) => {
         return res(ctx.delay(500), ctx.json(aktorId));

--- a/src/data/mock/api/veilarbperson.ts
+++ b/src/data/mock/api/veilarbperson.ts
@@ -676,7 +676,7 @@ const sykmeldtRegistering: RegistreringsData = {
 
 export const veilarbpersonHandlers: RequestHandler[] = [
     rest.get('/veilarbperson/api/person/cv_jobbprofil', (_, res, ctx) => {
-        return res(ctx.status(403));
+        return res(ctx.delay(500), ctx.json(cvOgJobbonsker));
     }),
     rest.get('/veilarbperson/api/person/aktorid', (_, res, ctx) => {
         return res(ctx.delay(500), ctx.json(aktorId));


### PR DESCRIPTION
Denne PR-en starta ut med at den skulle bli en generell løsning for feilmeldinger på alle kall. Nå virker det litt dumt at den ble så "generell", fordi det viser seg at vi egentlig bare trenger å vise en annen melding dersom veileder får 403 på jobbønsker... Men jeg klarer ikke helt å tenke hvordan vi burde gjøre det i stedet