### PR TITLE
Viste ikke info om at bruker ikke hadde registrert seg

### DIFF
--- a/src/components/registrering-innhold.tsx
+++ b/src/components/registrering-innhold.tsx
@@ -1,4 +1,4 @@
-import { Alert, HStack } from '@navikt/ds-react';
+import {Alert, HStack} from '@navikt/ds-react';
 import { useAppStore } from '../stores/app-store';
 import { Errormelding, Laster } from './felles/minikomponenter';
 import { ForeslattProfilering } from './registrering/foreslatt-profilering';
@@ -17,10 +17,10 @@ const Registreringsinnhold = () => {
         return <Laster />;
     }
 
-    if (registreringError?.status === 204 || registreringError?.status === 404 || !registreringData) {
+    if (registreringError?.status === 204 || registreringError?.status === 404 || !registreringData?.registrering) {
         return (
             <Alert inline variant="info" size="small">
-                Brukeren har ikke registrert seg
+                Brukeren har ikke registrert seg via den nye registreringsløsningen.
             </Alert>
         );
     } else if (registreringError) {

--- a/src/components/registrering-innhold.tsx
+++ b/src/components/registrering-innhold.tsx
@@ -1,4 +1,4 @@
-import {Alert, HStack} from '@navikt/ds-react';
+import { Alert, HStack } from '@navikt/ds-react';
 import { useAppStore } from '../stores/app-store';
 import { Errormelding, Laster } from './felles/minikomponenter';
 import { ForeslattProfilering } from './registrering/foreslatt-profilering';


### PR DESCRIPTION
Det kom ikke opp noen infoboks. Jeg debugget litt og ser at registreringerror og registreringerror?.status er undefined selv om kallet returnerer 204. I tillegg er ikke registreringdata tom, den har to elementer, registrering og type som kan være tom. Så ingen av sjekkene slo til. Dette fikser det, men jeg skjønner ikke helt hvor informasjonen om at det er en 204 ligger 🤔 