### PR TITLE
Fjern smooth scrolling på til toppen-knapp

### DIFF
--- a/src/components/felles/til-toppen-knapp.tsx
+++ b/src/components/felles/til-toppen-knapp.tsx
@@ -3,13 +3,6 @@ import { Button } from '@navikt/ds-react';
 import { ChevronRightLastIcon } from '@navikt/aksel-icons';
 import './til-toppen-knapp.css';
 
-const scrollTilElement = () => {
-    document.querySelector('#veilarbpersonflatefs-root')!.scrollIntoView({
-        block: 'start',
-        behavior: 'smooth'
-    });
-};
-
 const TilToppenKnapp = () => {
     const [synlig, setSynlig] = useState(false);
 
@@ -27,7 +20,9 @@ const TilToppenKnapp = () => {
                 <Button
                     variant="secondary"
                     icon={<ChevronRightLastIcon />}
-                    onClick={scrollTilElement}
+                    onClick={() => {
+                        window.scrollTo(0, 0);
+                    }}
                     id="til-toppen-knapp"
                 ></Button>
             )}


### PR DESCRIPTION
Det funker ikke i Chrome/Edge, virker som om skrolleanimasjonen blir avbrutt når knappen blir borte. I tillegg så er animasjoner så å si skrudd av i prod, så er kun vi som får glede av den smuude skrollingen uansett.