### PR TITLE
Fiks printing av personverninfo-modal

### DIFF
--- a/index.css
+++ b/index.css
@@ -38,3 +38,38 @@
 .kilde_tekst {
     color: var(--a-text-subtle);
 }
+
+@media print {
+    #veilarbpersonflatefs-root,
+    .nokkelinfo_panel,
+    .overblikk_chips,
+    .info_panel {
+        display: none;
+    }
+
+    #Registrering-panel {
+        display: block;
+    }
+
+    #Registrering-panel .info_container,
+    #Registrering-panel .informasjonsbolk,
+    .navds-modal__header,
+    .panel_header,
+    #til-toppen-knapp {
+        display: none;
+    }
+
+    .personvern_modal_innhold {
+        top: 0;
+    }
+
+    .personvern_modal_innhold ul {
+        margin-top: 0.25rem;
+        margin-bottom: 0.25rem;
+    }
+
+    a:link:after,
+    a:visited:after {
+        content: '';
+    }
+}

--- a/index.css
+++ b/index.css
@@ -43,14 +43,7 @@
     #veilarbpersonflatefs-root,
     .nokkelinfo_panel,
     .overblikk_chips,
-    .info_panel {
-        display: none;
-    }
-
-    #Registrering-panel {
-        display: block;
-    }
-
+    .info_panel,
     #Registrering-panel .info_container,
     #Registrering-panel .informasjonsbolk,
     .navds-modal__header,
@@ -59,8 +52,8 @@
         display: none;
     }
 
-    .personvern_modal_innhold {
-        top: 0;
+    #Registrering-panel {
+        display: block;
     }
 
     .personvern_modal_innhold ul {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,33 +9,33 @@
             "version": "0.0.0",
             "dependencies": {
                 "@mswjs/storage": "^0.1.0",
-                "@navikt/aksel-icons": "5.5.0",
-                "@navikt/ds-css": "5.5.0",
-                "@navikt/ds-react": "5.5.0",
+                "@navikt/aksel-icons": "5.6.4",
+                "@navikt/ds-css": "5.6.4",
+                "@navikt/ds-react": "5.6.4",
                 "constate": "^3.3.2",
                 "react": "18.2.0",
                 "react-dom": "18.2.0",
-                "swr": "2.2.2",
-                "vite-plugin-svgr": "^3.2.0"
+                "swr": "2.2.4",
+                "vite-plugin-svgr": "4.1.0"
             },
             "devDependencies": {
-                "@mswjs/data": "^0.13.0",
+                "@mswjs/data": "0.14.0",
                 "@testing-library/react": "^14.0.0",
-                "@types/react": "18.2.21",
-                "@types/react-dom": "18.2.7",
-                "@typescript-eslint/eslint-plugin": "6.7.0",
-                "@typescript-eslint/parser": "6.7.0",
-                "@vitejs/plugin-react": "4.0.4",
-                "eslint": "8.49.0",
+                "@types/react": "18.2.25",
+                "@types/react-dom": "18.2.11",
+                "@typescript-eslint/eslint-plugin": "6.7.4",
+                "@typescript-eslint/parser": "6.7.4",
+                "@vitejs/plugin-react": "4.1.0",
+                "eslint": "8.51.0",
                 "eslint-plugin-jsx-a11y": "^6.7.1",
                 "eslint-plugin-react-hooks": "^4.6.0",
                 "eslint-plugin-react-refresh": "0.4.3",
                 "jsdom": "^22.1.0",
-                "msw": "1.3.1",
+                "msw": "1.3.2",
                 "prettier": "3.0.3",
                 "typescript": "5.2.2",
-                "vite": "4.4.9",
-                "vitest": "0.34.4"
+                "vite": "4.4.11",
+                "vitest": "0.34.6"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -72,29 +72,29 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-            "integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.20.tgz",
+            "integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.11.tgz",
-            "integrity": "sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.0.tgz",
+            "integrity": "sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.22.10",
-                "@babel/generator": "^7.22.10",
-                "@babel/helper-compilation-targets": "^7.22.10",
-                "@babel/helper-module-transforms": "^7.22.9",
-                "@babel/helpers": "^7.22.11",
-                "@babel/parser": "^7.22.11",
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.11",
-                "@babel/types": "^7.22.11",
-                "convert-source-map": "^1.7.0",
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-compilation-targets": "^7.22.15",
+                "@babel/helper-module-transforms": "^7.23.0",
+                "@babel/helpers": "^7.23.0",
+                "@babel/parser": "^7.23.0",
+                "@babel/template": "^7.22.15",
+                "@babel/traverse": "^7.23.0",
+                "@babel/types": "^7.23.0",
+                "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
                 "json5": "^2.2.3",
@@ -117,11 +117,11 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
-            "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+            "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
             "dependencies": {
-                "@babel/types": "^7.22.10",
+                "@babel/types": "^7.23.0",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -131,12 +131,12 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
-            "integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+            "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
             "dependencies": {
                 "@babel/compat-data": "^7.22.9",
-                "@babel/helper-validator-option": "^7.22.5",
+                "@babel/helper-validator-option": "^7.22.15",
                 "browserslist": "^4.21.9",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -154,20 +154,20 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-            "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -185,26 +185,26 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-            "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+            "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.22.15"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
-            "integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+            "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-module-imports": "^7.22.5",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-module-imports": "^7.22.15",
                 "@babel/helper-simple-access": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/helper-validator-identifier": "^7.22.5"
+                "@babel/helper-validator-identifier": "^7.22.20"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -253,29 +253,29 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-            "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-            "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+            "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.11.tgz",
-            "integrity": "sha512-vyOXC8PBWaGc5h7GMsNx68OH33cypkEDJCHvYVVgVbbxJDROYVtexSk0gK5iCF1xNjRIN2s8ai7hwkWDq5szWg==",
+            "version": "7.23.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.1.tgz",
+            "integrity": "sha512-chNpneuK18yW5Oxsr+t553UZzzAs3aZnFm4bxhebsNTeshrC95yA7l5yl7GBAG+JG1rF0F7zzD2EixK9mWSDoA==",
             "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.11",
-                "@babel/types": "^7.22.11"
+                "@babel/template": "^7.22.15",
+                "@babel/traverse": "^7.23.0",
+                "@babel/types": "^7.23.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -295,9 +295,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.13.tgz",
-            "integrity": "sha512-3l6+4YOvc9wx7VlCSw4yQfcBo01ECA8TicQfbnCPuCEpRQrf+gTUyGdxNw+pyTUyywp6JRD1w0YQs9TpBXYlkw==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+            "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -347,31 +347,31 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-            "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
             "dependencies": {
-                "@babel/code-frame": "^7.22.5",
-                "@babel/parser": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/code-frame": "^7.22.13",
+                "@babel/parser": "^7.22.15",
+                "@babel/types": "^7.22.15"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.11.tgz",
-            "integrity": "sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
+            "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
             "dependencies": {
-                "@babel/code-frame": "^7.22.10",
-                "@babel/generator": "^7.22.10",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.11",
-                "@babel/types": "^7.22.11",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -380,12 +380,12 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
-            "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+            "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -785,34 +785,38 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
-            "integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
+            "version": "8.51.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
+            "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
-            "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+            "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+            "dependencies": {
+                "@floating-ui/utils": "^0.1.3"
+            }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.2.tgz",
-            "integrity": "sha512-VKmvHVatWnewmGGy+7Mdy4cTJX71Pli6v/Wjb5RQBuq5wjUYx+Ef+kRThi8qggZqDgD8CogCpqhRoVp3+yQk+g==",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+            "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
             "dependencies": {
-                "@floating-ui/core": "^1.3.1"
+                "@floating-ui/core": "^1.4.2",
+                "@floating-ui/utils": "^0.1.3"
             }
         },
         "node_modules/@floating-ui/react": {
-            "version": "0.24.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.1.tgz",
-            "integrity": "sha512-qjCKUZDEz/4bnJmu4gn66TqsoX912/re8JGEi3pXazsphmyh327l0UpTgpBAT3WkNbnzAH7Adt3wKlLMNtfupw==",
+            "version": "0.25.4",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.25.4.tgz",
+            "integrity": "sha512-lWRQ/UiTvSIBxohn0/2HFHEmnmOVRjl7j6XcRJuLH0ls6f/9AyHMWVzkAJFuwx0n9gaEeCmg9VccCSCJzbEJig==",
             "dependencies": {
-                "@floating-ui/react-dom": "^2.0.0",
-                "aria-hidden": "^1.1.3",
+                "@floating-ui/react-dom": "^2.0.2",
+                "@floating-ui/utils": "^0.1.1",
                 "tabbable": "^6.0.1"
             },
             "peerDependencies": {
@@ -821,16 +825,21 @@
             }
         },
         "node_modules/@floating-ui/react-dom": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-            "integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
+            "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
             "dependencies": {
-                "@floating-ui/dom": "^1.3.0"
+                "@floating-ui/dom": "^1.5.1"
             },
             "peerDependencies": {
                 "react": ">=16.8.0",
                 "react-dom": ">=16.8.0"
             }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+            "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
         },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.11",
@@ -939,9 +948,9 @@
             }
         },
         "node_modules/@mswjs/data": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@mswjs/data/-/data-0.13.0.tgz",
-            "integrity": "sha512-0EeDQ5TF4O3nBQ6Y8/XY58YeTrKH5is/EuA0xf3o6sF3ftvhtLkSLSpFhd1dXASKzQprWzQDVxzaSYsmKPiXtg==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/@mswjs/data/-/data-0.14.0.tgz",
+            "integrity": "sha512-t51a8AWa0g19FPFOc3W4Lw0Lo39iWyTKy4fWJDWORGHjitJRepvbgs7ufm7O30r2ZaFSALhCUVyyocuii0dNqA==",
             "dev": true,
             "dependencies": {
                 "@types/lodash": "^4.14.172",
@@ -1011,23 +1020,23 @@
             "integrity": "sha512-R9rOWsIXPSbYVkZ2DOqJLeFiGBylSP7eiTMjqukro/46Lm7e0IOM9Xy8o7jr27IKBI3m9U0o0yxGFCd0CpgAGg=="
         },
         "node_modules/@navikt/aksel-icons": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@navikt/aksel-icons/-/aksel-icons-5.5.0.tgz",
-            "integrity": "sha512-KKq28Ed4lYwnrESIyyOxnBGr7ef1RqTPZoLAJE1YXNGHfVMN/TEZCoZQlPialhZK8g36ngNgvtsZeEm5oCxoxQ=="
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@navikt/aksel-icons/-/aksel-icons-5.6.4.tgz",
+            "integrity": "sha512-O4BjhWaxORzpU/Y3AMSylSnPU0IC5rYZUi5N580h7HeEcEYXL+cBCaWqvzkQdK/NIuW6GMMpEABayw1xlUszYA=="
         },
         "node_modules/@navikt/ds-css": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-5.5.0.tgz",
-            "integrity": "sha512-8QFCSyBY1B49L7w65xf+eBHSVjGHPFmhq5vrIijyeq7CbFGxH5ZQNkGZuQr5WE+cKhHk/ViOmA/FJUR++VWBCA=="
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-5.6.4.tgz",
+            "integrity": "sha512-2nqwCxzyp59yLA51xnTKTyu1vyDj96P10kxfOo0jIMiNoM430fSx6ayqdd1x60H7HYlzj8wDtvB/tcPnGBHehg=="
         },
         "node_modules/@navikt/ds-react": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-5.5.0.tgz",
-            "integrity": "sha512-sBX0q7MjkAVBYvE8mrNkb2YwF0Cx/TNLIjN96bnLOnqfHRB8CV2+lkYNR6u+c/8qOuPZXgyH25dqye9kMC4VdQ==",
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-5.6.4.tgz",
+            "integrity": "sha512-R1PKdWpD2JN7pb7vES5lKgiBYgYJsi41g3OozsDdHUxuNQovXkhbTUQGVKNSWLrYwLOYcIbXf5ZqsfabtSLJyw==",
             "dependencies": {
-                "@floating-ui/react": "0.24.1",
-                "@navikt/aksel-icons": "^5.5.0",
-                "@navikt/ds-tokens": "^5.5.0",
+                "@floating-ui/react": "0.25.4",
+                "@navikt/aksel-icons": "^5.6.4",
+                "@navikt/ds-tokens": "^5.6.4",
                 "@radix-ui/react-tabs": "1.0.0",
                 "@radix-ui/react-toggle-group": "1.0.0",
                 "clsx": "^1.2.1",
@@ -1045,9 +1054,9 @@
             }
         },
         "node_modules/@navikt/ds-tokens": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-5.5.0.tgz",
-            "integrity": "sha512-zV9TfGNjiRgpX1Ec11gK8BtgkiR+HN+qwjVbWt5NA6ux8xIQYdaFqLJWQa585vLl6DEOhwrlzb0FhT+KDvG3Rg=="
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-5.6.4.tgz",
+            "integrity": "sha512-yyLcVESKCAk6bUuL78uON2rbH35WDdWBNvUagf1pvTw9zeptgFuTho8IxpcpQHuY2NZLDZsn5RajloDg3C9GZw=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -1308,9 +1317,9 @@
             }
         },
         "node_modules/@rollup/pluginutils": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.3.tgz",
-            "integrity": "sha512-hfllNN4a80rwNQ9QCxhxuHCGHMAvabXqxNdaChUSSadMre7t4iEUI6fFAhBOn/eIYTgYVhBv7vCLsAJ4u3lf3g==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+            "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
             "dependencies": {
                 "@types/estree": "^1.0.0",
                 "estree-walker": "^2.0.2",
@@ -1320,7 +1329,7 @@
                 "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0||^3.0.0"
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
             },
             "peerDependenciesMeta": {
                 "rollup": {
@@ -1335,9 +1344,9 @@
             "dev": true
         },
         "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-7.0.0.tgz",
-            "integrity": "sha512-khWbXesWIP9v8HuKCl2NU2HNAyqpSQ/vkIl36Nbn4HIwEYSRWL0H7Gs6idJdha2DkpFDWlsqMELvoCE8lfFY6Q==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
+            "integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==",
             "engines": {
                 "node": ">=14"
             },
@@ -1350,9 +1359,9 @@
             }
         },
         "node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-7.0.0.tgz",
-            "integrity": "sha512-iiZaIvb3H/c7d3TH2HBeK91uI2rMhZNwnsIrvd7ZwGLkFw6mmunOCoVnjdYua662MqGFxlN9xTq4fv9hgR4VXQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-8.0.0.tgz",
+            "integrity": "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==",
             "engines": {
                 "node": ">=14"
             },
@@ -1365,9 +1374,9 @@
             }
         },
         "node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-7.0.0.tgz",
-            "integrity": "sha512-sQQmyo+qegBx8DfFc04PFmIO1FP1MHI1/QEpzcIcclo5OAISsOJPW76ZIs0bDyO/DBSJEa/tDa1W26pVtt0FRw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-8.0.0.tgz",
+            "integrity": "sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==",
             "engines": {
                 "node": ">=14"
             },
@@ -1380,9 +1389,9 @@
             }
         },
         "node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-7.0.0.tgz",
-            "integrity": "sha512-i6MaAqIZXDOJeikJuzocByBf8zO+meLwfQ/qMHIjCcvpnfvWf82PFvredEZElErB5glQFJa2KVKk8N2xV6tRRA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-8.0.0.tgz",
+            "integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==",
             "engines": {
                 "node": ">=14"
             },
@@ -1395,9 +1404,9 @@
             }
         },
         "node_modules/@svgr/babel-plugin-svg-dynamic-title": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-7.0.0.tgz",
-            "integrity": "sha512-BoVSh6ge3SLLpKC0pmmN9DFlqgFy4NxNgdZNLPNJWBUU7TQpDWeBuyVuDW88iXydb5Cv0ReC+ffa5h3VrKfk1w==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-8.0.0.tgz",
+            "integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==",
             "engines": {
                 "node": ">=14"
             },
@@ -1410,9 +1419,9 @@
             }
         },
         "node_modules/@svgr/babel-plugin-svg-em-dimensions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-7.0.0.tgz",
-            "integrity": "sha512-tNDcBa+hYn0gO+GkP/AuNKdVtMufVhU9fdzu+vUQsR18RIJ9RWe7h/pSBY338RO08wArntwbDk5WhQBmhf2PaA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-8.0.0.tgz",
+            "integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==",
             "engines": {
                 "node": ">=14"
             },
@@ -1425,9 +1434,9 @@
             }
         },
         "node_modules/@svgr/babel-plugin-transform-react-native-svg": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-7.0.0.tgz",
-            "integrity": "sha512-qw54u8ljCJYL2KtBOjI5z7Nzg8LnSvQOP5hPKj77H4VQL4+HdKbAT5pnkkZLmHKYwzsIHSYKXxHouD8zZamCFQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-8.1.0.tgz",
+            "integrity": "sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==",
             "engines": {
                 "node": ">=14"
             },
@@ -1440,9 +1449,9 @@
             }
         },
         "node_modules/@svgr/babel-plugin-transform-svg-component": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-7.0.0.tgz",
-            "integrity": "sha512-CcFECkDj98daOg9jE3Bh3uyD9kzevCAnZ+UtzG6+BQG/jOQ2OA3jHnX6iG4G1MCJkUQFnUvEv33NvQfqrb/F3A==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-8.0.0.tgz",
+            "integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==",
             "engines": {
                 "node": ">=12"
             },
@@ -1455,18 +1464,18 @@
             }
         },
         "node_modules/@svgr/babel-preset": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-7.0.0.tgz",
-            "integrity": "sha512-EX/NHeFa30j5UjldQGVQikuuQNHUdGmbh9kEpBKofGUtF0GUPJ4T4rhoYiqDAOmBOxojyot36JIFiDUHUK1ilQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-8.1.0.tgz",
+            "integrity": "sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==",
             "dependencies": {
-                "@svgr/babel-plugin-add-jsx-attribute": "^7.0.0",
-                "@svgr/babel-plugin-remove-jsx-attribute": "^7.0.0",
-                "@svgr/babel-plugin-remove-jsx-empty-expression": "^7.0.0",
-                "@svgr/babel-plugin-replace-jsx-attribute-value": "^7.0.0",
-                "@svgr/babel-plugin-svg-dynamic-title": "^7.0.0",
-                "@svgr/babel-plugin-svg-em-dimensions": "^7.0.0",
-                "@svgr/babel-plugin-transform-react-native-svg": "^7.0.0",
-                "@svgr/babel-plugin-transform-svg-component": "^7.0.0"
+                "@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
+                "@svgr/babel-plugin-remove-jsx-attribute": "8.0.0",
+                "@svgr/babel-plugin-remove-jsx-empty-expression": "8.0.0",
+                "@svgr/babel-plugin-replace-jsx-attribute-value": "8.0.0",
+                "@svgr/babel-plugin-svg-dynamic-title": "8.0.0",
+                "@svgr/babel-plugin-svg-em-dimensions": "8.0.0",
+                "@svgr/babel-plugin-transform-react-native-svg": "8.1.0",
+                "@svgr/babel-plugin-transform-svg-component": "8.0.0"
             },
             "engines": {
                 "node": ">=14"
@@ -1480,14 +1489,15 @@
             }
         },
         "node_modules/@svgr/core": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/core/-/core-7.0.0.tgz",
-            "integrity": "sha512-ztAoxkaKhRVloa3XydohgQQCb0/8x9T63yXovpmHzKMkHO6pkjdsIAWKOS4bE95P/2quVh1NtjSKlMRNzSBffw==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
+            "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "dependencies": {
                 "@babel/core": "^7.21.3",
-                "@svgr/babel-preset": "^7.0.0",
+                "@svgr/babel-preset": "8.1.0",
                 "camelcase": "^6.2.0",
-                "cosmiconfig": "^8.1.3"
+                "cosmiconfig": "^8.1.3",
+                "snake-case": "^3.0.4"
             },
             "engines": {
                 "node": ">=14"
@@ -1498,9 +1508,9 @@
             }
         },
         "node_modules/@svgr/hast-util-to-babel-ast": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-7.0.0.tgz",
-            "integrity": "sha512-42Ej9sDDEmsJKjrfQ1PHmiDiHagh/u9AHO9QWbeNx4KmD9yS5d1XHmXUNINfUcykAU+4431Cn+k6Vn5mWBYimQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-8.0.0.tgz",
+            "integrity": "sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==",
             "dependencies": {
                 "@babel/types": "^7.21.3",
                 "entities": "^4.4.0"
@@ -1514,13 +1524,13 @@
             }
         },
         "node_modules/@svgr/plugin-jsx": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-7.0.0.tgz",
-            "integrity": "sha512-SWlTpPQmBUtLKxXWgpv8syzqIU8XgFRvyhfkam2So8b3BE0OS0HPe5UfmlJ2KIC+a7dpuuYovPR2WAQuSyMoPw==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-8.1.0.tgz",
+            "integrity": "sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==",
             "dependencies": {
                 "@babel/core": "^7.21.3",
-                "@svgr/babel-preset": "^7.0.0",
-                "@svgr/hast-util-to-babel-ast": "^7.0.0",
+                "@svgr/babel-preset": "8.1.0",
+                "@svgr/hast-util-to-babel-ast": "8.0.0",
                 "svg-parser": "^2.0.4"
             },
             "engines": {
@@ -1529,6 +1539,9 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/gregberge"
+            },
+            "peerDependencies": {
+                "@svgr/core": "*"
             }
         },
         "node_modules/@testing-library/dom": {
@@ -1685,6 +1698,47 @@
             "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
             "dev": true
         },
+        "node_modules/@types/babel__core": {
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.2.tgz",
+            "integrity": "sha512-pNpr1T1xLUc2l3xJKuPtsEky3ybxN3m4fJkknfIpTCTfIZCDW57oAg+EfCgIIp2rvCe0Wn++/FfodDS4YXxBwA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "node_modules/@types/babel__generator": {
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.5.tgz",
+            "integrity": "sha512-h9yIuWbJKdOPLJTbmSpPzkF67e659PbQDba7ifWm5BJ8xTv+sDmS7rFmywkWOvXedGTivCdeGSIIX8WLcRTz8w==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__template": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.2.tgz",
+            "integrity": "sha512-/AVzPICMhMOMYoSx9MoKpGDKdBRsIXMNByh1PXSZoa+v6ZoLa8xxtsT/uLQ/NJm0XVAWl/BvId4MlDeXJaeIZQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__traverse": {
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.2.tgz",
+            "integrity": "sha512-ojlGK1Hsfce93J0+kn3H5R73elidKUaZonirN33GSmgTUMpzI/MIFfSpF3haANe3G1bEBS9/9/QEqwTzwqFsKw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.20.7"
+            }
+        },
         "node_modules/@types/chai": {
             "version": "4.3.5",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
@@ -1716,9 +1770,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-            "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
+            "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
         },
         "node_modules/@types/js-levenshtein": {
             "version": "1.1.1",
@@ -1727,9 +1781,9 @@
             "dev": true
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.12",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-            "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+            "version": "7.0.13",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+            "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
             "dev": true
         },
         "node_modules/@types/lodash": {
@@ -1769,9 +1823,9 @@
             "devOptional": true
         },
         "node_modules/@types/react": {
-            "version": "18.2.21",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
-            "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
+            "version": "18.2.25",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.25.tgz",
+            "integrity": "sha512-24xqse6+VByVLIr+xWaQ9muX1B4bXJKXBbjszbld/UEDslGLY53+ZucF44HCmLbMPejTzGG9XgR+3m2/Wqu1kw==",
             "devOptional": true,
             "dependencies": {
                 "@types/prop-types": "*",
@@ -1780,9 +1834,9 @@
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.2.7",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
-            "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+            "version": "18.2.11",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.11.tgz",
+            "integrity": "sha512-zq6Dy0EiCuF9pWFW6I6k6W2LdpUixLE4P6XjXU1QHLfak3GPACQfLwEuHzY5pOYa4hzj1d0GxX/P141aFjZsyg==",
             "dev": true,
             "dependencies": {
                 "@types/react": "*"
@@ -1795,9 +1849,9 @@
             "devOptional": true
         },
         "node_modules/@types/semver": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.2.tgz",
-            "integrity": "sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
+            "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
             "dev": true
         },
         "node_modules/@types/set-cookie-parser": {
@@ -1816,16 +1870,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.0.tgz",
-            "integrity": "sha512-gUqtknHm0TDs1LhY12K2NA3Rmlmp88jK9Tx8vGZMfHeNMLE3GH2e9TRub+y+SOjuYgtOmok+wt1AyDPZqxbNag==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.4.tgz",
+            "integrity": "sha512-DAbgDXwtX+pDkAHwiGhqP3zWUGpW49B7eqmgpPtg+BKJXwdct79ut9+ifqOFPJGClGKSHXn2PTBatCnldJRUoA==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.7.0",
-                "@typescript-eslint/type-utils": "6.7.0",
-                "@typescript-eslint/utils": "6.7.0",
-                "@typescript-eslint/visitor-keys": "6.7.0",
+                "@typescript-eslint/scope-manager": "6.7.4",
+                "@typescript-eslint/type-utils": "6.7.4",
+                "@typescript-eslint/utils": "6.7.4",
+                "@typescript-eslint/visitor-keys": "6.7.4",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -1851,15 +1905,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.0.tgz",
-            "integrity": "sha512-jZKYwqNpNm5kzPVP5z1JXAuxjtl2uG+5NpaMocFPTNC2EdYIgbXIPImObOkhbONxtFTTdoZstLZefbaK+wXZng==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.4.tgz",
+            "integrity": "sha512-I5zVZFY+cw4IMZUeNCU7Sh2PO5O57F7Lr0uyhgCJmhN/BuTlnc55KxPonR4+EM3GBdfiCyGZye6DgMjtubQkmA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.7.0",
-                "@typescript-eslint/types": "6.7.0",
-                "@typescript-eslint/typescript-estree": "6.7.0",
-                "@typescript-eslint/visitor-keys": "6.7.0",
+                "@typescript-eslint/scope-manager": "6.7.4",
+                "@typescript-eslint/types": "6.7.4",
+                "@typescript-eslint/typescript-estree": "6.7.4",
+                "@typescript-eslint/visitor-keys": "6.7.4",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1879,13 +1933,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.0.tgz",
-            "integrity": "sha512-lAT1Uau20lQyjoLUQ5FUMSX/dS07qux9rYd5FGzKz/Kf8W8ccuvMyldb8hadHdK/qOI7aikvQWqulnEq2nCEYA==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.4.tgz",
+            "integrity": "sha512-SdGqSLUPTXAXi7c3Ob7peAGVnmMoGzZ361VswK2Mqf8UOYcODiYvs8rs5ILqEdfvX1lE7wEZbLyELCW+Yrql1A==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.7.0",
-                "@typescript-eslint/visitor-keys": "6.7.0"
+                "@typescript-eslint/types": "6.7.4",
+                "@typescript-eslint/visitor-keys": "6.7.4"
             },
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -1896,13 +1950,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.0.tgz",
-            "integrity": "sha512-f/QabJgDAlpSz3qduCyQT0Fw7hHpmhOzY/Rv6zO3yO+HVIdPfIWhrQoAyG+uZVtWAIS85zAyzgAFfyEr+MgBpg==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.4.tgz",
+            "integrity": "sha512-n+g3zi1QzpcAdHFP9KQF+rEFxMb2KxtnJGID3teA/nxKHOVi3ylKovaqEzGBbVY2pBttU6z85gp0D00ufLzViQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.7.0",
-                "@typescript-eslint/utils": "6.7.0",
+                "@typescript-eslint/typescript-estree": "6.7.4",
+                "@typescript-eslint/utils": "6.7.4",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -1923,9 +1977,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.0.tgz",
-            "integrity": "sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.4.tgz",
+            "integrity": "sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==",
             "dev": true,
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -1936,13 +1990,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.0.tgz",
-            "integrity": "sha512-dPvkXj3n6e9yd/0LfojNU8VMUGHWiLuBZvbM6V6QYD+2qxqInE7J+J/ieY2iGwR9ivf/R/haWGkIj04WVUeiSQ==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.4.tgz",
+            "integrity": "sha512-ty8b5qHKatlNYd9vmpHooQz3Vki3gG+3PchmtsA4TgrZBKWHNjWfkQid7K7xQogBqqc7/BhGazxMD5vr6Ha+iQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.7.0",
-                "@typescript-eslint/visitor-keys": "6.7.0",
+                "@typescript-eslint/types": "6.7.4",
+                "@typescript-eslint/visitor-keys": "6.7.4",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -1963,17 +2017,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.0.tgz",
-            "integrity": "sha512-MfCq3cM0vh2slSikQYqK2Gq52gvOhe57vD2RM3V4gQRZYX4rDPnKLu5p6cm89+LJiGlwEXU8hkYxhqqEC/V3qA==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.4.tgz",
+            "integrity": "sha512-PRQAs+HUn85Qdk+khAxsVV+oULy3VkbH3hQ8hxLRJXWBEd7iI+GbQxH5SEUSH7kbEoTp6oT1bOwyga24ELALTA==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.7.0",
-                "@typescript-eslint/types": "6.7.0",
-                "@typescript-eslint/typescript-estree": "6.7.0",
+                "@typescript-eslint/scope-manager": "6.7.4",
+                "@typescript-eslint/types": "6.7.4",
+                "@typescript-eslint/typescript-estree": "6.7.4",
                 "semver": "^7.5.4"
             },
             "engines": {
@@ -1988,12 +2042,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.0.tgz",
-            "integrity": "sha512-/C1RVgKFDmGMcVGeD8HjKv2bd72oI1KxQDeY8uc66gw9R0OK0eMq48cA+jv9/2Ag6cdrsUGySm1yzYmfz0hxwQ==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.4.tgz",
+            "integrity": "sha512-pOW37DUhlTZbvph50x5zZCkFn3xzwkGtNoJHzIM3svpiSkJzwOYr/kVBaXmf+RAQiUDs1AHEZVNPg6UJCJpwRA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.7.0",
+                "@typescript-eslint/types": "6.7.4",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
@@ -2005,14 +2059,15 @@
             }
         },
         "node_modules/@vitejs/plugin-react": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.0.4.tgz",
-            "integrity": "sha512-7wU921ABnNYkETiMaZy7XqpueMnpu5VxvVps13MjmCo+utBdD79sZzrApHawHtVX66cCJQQTXFcjH0y9dSUK8g==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.1.0.tgz",
+            "integrity": "sha512-rM0SqazU9iqPUraQ2JlIvReeaxOoRj6n+PzB1C0cBzIbd8qP336nC39/R9yPi3wVcah7E7j/kdU1uCUqMEU4OQ==",
             "dev": true,
             "dependencies": {
-                "@babel/core": "^7.22.9",
+                "@babel/core": "^7.22.20",
                 "@babel/plugin-transform-react-jsx-self": "^7.22.5",
                 "@babel/plugin-transform-react-jsx-source": "^7.22.5",
+                "@types/babel__core": "^7.20.2",
                 "react-refresh": "^0.14.0"
             },
             "engines": {
@@ -2023,26 +2078,26 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.4.tgz",
-            "integrity": "sha512-XlMKX8HyYUqB8dsY8Xxrc64J2Qs9pKMt2Z8vFTL4mBWXJsg4yoALHzJfDWi8h5nkO4Zua4zjqtapQ/IluVkSnA==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.6.tgz",
+            "integrity": "sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==",
             "dev": true,
             "dependencies": {
-                "@vitest/spy": "0.34.4",
-                "@vitest/utils": "0.34.4",
-                "chai": "^4.3.7"
+                "@vitest/spy": "0.34.6",
+                "@vitest/utils": "0.34.6",
+                "chai": "^4.3.10"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.4.tgz",
-            "integrity": "sha512-hwwdB1StERqUls8oV8YcpmTIpVeJMe4WgYuDongVzixl5hlYLT2G8afhcdADeDeqCaAmZcSgLTLtqkjPQF7x+w==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.6.tgz",
+            "integrity": "sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==",
             "dev": true,
             "dependencies": {
-                "@vitest/utils": "0.34.4",
+                "@vitest/utils": "0.34.6",
                 "p-limit": "^4.0.0",
                 "pathe": "^1.1.1"
             },
@@ -2078,9 +2133,9 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.4.tgz",
-            "integrity": "sha512-GCsh4coc3YUSL/o+BPUo7lHQbzpdttTxL6f4q0jRx2qVGoYz/cyTRDJHbnwks6TILi6560bVWoBpYC10PuTLHw==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.6.tgz",
+            "integrity": "sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==",
             "dev": true,
             "dependencies": {
                 "magic-string": "^0.30.1",
@@ -2092,9 +2147,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.4.tgz",
-            "integrity": "sha512-PNU+fd7DUPgA3Ya924b1qKuQkonAW6hL7YUjkON3wmBwSTIlhOSpy04SJ0NrRsEbrXgMMj6Morh04BMf8k+w0g==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.6.tgz",
+            "integrity": "sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==",
             "dev": true,
             "dependencies": {
                 "tinyspy": "^2.1.1"
@@ -2104,9 +2159,9 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.4.tgz",
-            "integrity": "sha512-yR2+5CHhp/K4ySY0Qtd+CAL9f5Yh1aXrKfAT42bq6CtlGPh92jIDDDSg7ydlRow1CP+dys4TrOrbELOyNInHSg==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.6.tgz",
+            "integrity": "sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==",
             "dev": true,
             "dependencies": {
                 "diff-sequences": "^29.4.3",
@@ -2261,22 +2316,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "node_modules/aria-hidden": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
-            "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
-            "dependencies": {
-                "tslib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/aria-hidden/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
         },
         "node_modules/aria-query": {
             "version": "5.1.3",
@@ -2504,9 +2543,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.21.10",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-            "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+            "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2522,10 +2561,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001517",
-                "electron-to-chromium": "^1.4.477",
+                "caniuse-lite": "^1.0.30001541",
+                "electron-to-chromium": "^1.4.535",
                 "node-releases": "^2.0.13",
-                "update-browserslist-db": "^1.0.11"
+                "update-browserslist-db": "^1.0.13"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2600,9 +2639,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001524",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
-            "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
+            "version": "1.0.30001546",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001546.tgz",
+            "integrity": "sha512-zvtSJwuQFpewSyRrI3AsftF6rM0X80mZkChIt1spBGEvRglCrjTniXvinc8JKRoqTwXAgvqTImaN9igfSMtUBw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2619,18 +2658,18 @@
             ]
         },
         "node_modules/chai": {
-            "version": "4.3.8",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.8.tgz",
-            "integrity": "sha512-vX4YvVVtxlfSZ2VecZgFUTU5qPCYsobVI2O9FmwEXBhDigYGQA6jRXCycIs1yJnnWbZ6/+a2zNIF5DfVCcJBFQ==",
+            "version": "4.3.10",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+            "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
             "dev": true,
             "dependencies": {
                 "assertion-error": "^1.1.0",
-                "check-error": "^1.0.2",
-                "deep-eql": "^4.1.2",
-                "get-func-name": "^2.0.0",
-                "loupe": "^2.3.1",
+                "check-error": "^1.0.3",
+                "deep-eql": "^4.1.3",
+                "get-func-name": "^2.0.2",
+                "loupe": "^2.3.6",
                 "pathval": "^1.1.1",
-                "type-detect": "^4.0.5"
+                "type-detect": "^4.0.8"
             },
             "engines": {
                 "node": ">=4"
@@ -2665,10 +2704,13 @@
             }
         },
         "node_modules/check-error": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-            "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
             "dev": true,
+            "dependencies": {
+                "get-func-name": "^2.0.2"
+            },
             "engines": {
                 "node": "*"
             }
@@ -2821,9 +2863,9 @@
             }
         },
         "node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
         },
         "node_modules/cookie": {
             "version": "0.4.2",
@@ -2835,13 +2877,13 @@
             }
         },
         "node_modules/cosmiconfig": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-            "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+            "version": "8.3.6",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+            "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
             "dependencies": {
-                "import-fresh": "^3.2.1",
+                "import-fresh": "^3.3.0",
                 "js-yaml": "^4.1.0",
-                "parse-json": "^5.0.0",
+                "parse-json": "^5.2.0",
                 "path-type": "^4.0.0"
             },
             "engines": {
@@ -2849,6 +2891,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/cross-spawn": {
@@ -3133,10 +3183,19 @@
                 "node": ">=12"
             }
         },
+        "node_modules/dot-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+            "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.504",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.504.tgz",
-            "integrity": "sha512-cSMwIAd8yUh54VwitVRVvHK66QqHWE39C3DRj8SWiXitEpVSY3wNPD9y1pxQtLIi4w3UdzF9klLsmuPshz09DQ=="
+            "version": "1.4.544",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.544.tgz",
+            "integrity": "sha512-54z7squS1FyFRSUqq/knOFSptjjogLZXbKcYk3B0qkE1KZzvqASwRZnY2KzZQJqIYLVD38XZeoiMRflYSwyO4w=="
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -3329,15 +3388,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
-            "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
+            "version": "8.51.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
+            "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.2",
-                "@eslint/js": "8.49.0",
+                "@eslint/js": "8.51.0",
                 "@humanwhocodes/config-array": "^0.11.11",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -3882,9 +3941,9 @@
             }
         },
         "node_modules/get-func-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-            "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
             "dev": true,
             "engines": {
                 "node": "*"
@@ -4015,9 +4074,9 @@
             "dev": true
         },
         "node_modules/graphql": {
-            "version": "16.7.1",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz",
-            "integrity": "sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==",
+            "version": "16.8.1",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+            "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -5050,6 +5109,14 @@
                 "get-func-name": "^2.0.0"
             }
         },
+        "node_modules/lower-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+            "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
         "node_modules/lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5068,9 +5135,9 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.3",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
-            "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
+            "version": "0.30.4",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.4.tgz",
+            "integrity": "sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -5172,9 +5239,9 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/msw": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.1.tgz",
-            "integrity": "sha512-GhP5lHSTXNlZb9EaKgPRJ01YAnVXwzkvnTzRn4W8fxU2DXuJrRO+Nb6OHdYqB4fCkwSNpIJH9JkON5Y6rHqJMQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.2.tgz",
+            "integrity": "sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -5186,7 +5253,7 @@
                 "chalk": "^4.1.1",
                 "chokidar": "^3.4.2",
                 "cookie": "^0.4.2",
-                "graphql": "^15.0.0 || ^16.0.0",
+                "graphql": "^16.8.1",
                 "headers-polyfill": "3.2.5",
                 "inquirer": "^8.2.0",
                 "is-node-process": "^1.2.0",
@@ -5327,6 +5394,15 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
+        },
+        "node_modules/no-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+            "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+            "dependencies": {
+                "lower-case": "^2.0.2",
+                "tslib": "^2.0.3"
+            }
         },
         "node_modules/node-fetch": {
             "version": "2.6.11",
@@ -5831,9 +5907,9 @@
             }
         },
         "node_modules/pretty-format": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
-            "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "dev": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
@@ -6119,12 +6195,6 @@
                 "tslib": "^2.1.0"
             }
         },
-        "node_modules/rxjs/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-            "dev": true
-        },
         "node_modules/safe-array-concat": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
@@ -6298,6 +6368,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/snake-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+            "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+            "dependencies": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -6457,9 +6536,9 @@
             "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
         },
         "node_modules/swr": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.2.tgz",
-            "integrity": "sha512-CbR41AoMD4TQBQw9ic3GTXspgfM9Y8Mdhb5Ob4uIKXhWqnRLItwA5fpGvB7SmSw3+zEjb0PdhiEumtUvYoQ+bQ==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.4.tgz",
+            "integrity": "sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==",
             "dependencies": {
                 "client-only": "^0.0.1",
                 "use-sync-external-store": "^1.2.0"
@@ -6475,9 +6554,9 @@
             "dev": true
         },
         "node_modules/tabbable": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
-            "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ=="
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
         },
         "node_modules/text-table": {
             "version": "0.2.0",
@@ -6507,9 +6586,9 @@
             }
         },
         "node_modules/tinyspy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
-            "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.0.tgz",
+            "integrity": "sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==",
             "dev": true,
             "engines": {
                 "node": ">=14.0.0"
@@ -6579,6 +6658,11 @@
             "peerDependencies": {
                 "typescript": ">=4.2.0"
             }
+        },
+        "node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -6682,7 +6766,7 @@
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
             "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-            "dev": true,
+            "devOptional": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6692,9 +6776,9 @@
             }
         },
         "node_modules/ufo": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.0.tgz",
-            "integrity": "sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.1.tgz",
+            "integrity": "sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==",
             "dev": true
         },
         "node_modules/unbox-primitive": {
@@ -6722,9 +6806,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-            "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6806,9 +6890,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.4.9",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-            "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+            "version": "4.4.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
+            "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
             "dependencies": {
                 "esbuild": "^0.18.10",
                 "postcss": "^8.4.27",
@@ -6860,9 +6944,9 @@
             }
         },
         "node_modules/vite-node": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.4.tgz",
-            "integrity": "sha512-ho8HtiLc+nsmbwZMw8SlghESEE3KxJNp04F/jPUCLVvaURwt0d+r9LxEqCX5hvrrOQ0GSyxbYr5ZfRYhQ0yVKQ==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.6.tgz",
+            "integrity": "sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==",
             "dev": true,
             "dependencies": {
                 "cac": "^6.7.14",
@@ -6870,7 +6954,7 @@
                 "mlly": "^1.4.0",
                 "pathe": "^1.1.1",
                 "picocolors": "^1.0.0",
-                "vite": "^3.0.0 || ^4.0.0"
+                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
             },
             "bin": {
                 "vite-node": "vite-node.mjs"
@@ -6883,36 +6967,36 @@
             }
         },
         "node_modules/vite-plugin-svgr": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-3.2.0.tgz",
-            "integrity": "sha512-Uvq6niTvhqJU6ga78qLKBFJSDvxWhOnyfQSoKpDPMAGxJPo5S3+9hyjExE5YDj6Lpa4uaLkGc1cBgxXov+LjSw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-4.1.0.tgz",
+            "integrity": "sha512-v7Qic+FWmCChgQNGSI4V8X63OEYsdUoLt66iqIcHozq9bfK/Dwmr0V+LBy1NE8CE98Y8HouEBJ+pto4AMfN5xw==",
             "dependencies": {
-                "@rollup/pluginutils": "^5.0.2",
-                "@svgr/core": "^7.0.0",
-                "@svgr/plugin-jsx": "^7.0.0"
+                "@rollup/pluginutils": "^5.0.4",
+                "@svgr/core": "^8.1.0",
+                "@svgr/plugin-jsx": "^8.1.0"
             },
             "peerDependencies": {
                 "vite": "^2.6.0 || 3 || 4"
             }
         },
         "node_modules/vitest": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.4.tgz",
-            "integrity": "sha512-SE/laOsB6995QlbSE6BtkpXDeVNLJc1u2LHRG/OpnN4RsRzM3GQm4nm3PQCK5OBtrsUqnhzLdnT7se3aeNGdlw==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.6.tgz",
+            "integrity": "sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==",
             "dev": true,
             "dependencies": {
                 "@types/chai": "^4.3.5",
                 "@types/chai-subset": "^1.3.3",
                 "@types/node": "*",
-                "@vitest/expect": "0.34.4",
-                "@vitest/runner": "0.34.4",
-                "@vitest/snapshot": "0.34.4",
-                "@vitest/spy": "0.34.4",
-                "@vitest/utils": "0.34.4",
+                "@vitest/expect": "0.34.6",
+                "@vitest/runner": "0.34.6",
+                "@vitest/snapshot": "0.34.6",
+                "@vitest/spy": "0.34.6",
+                "@vitest/utils": "0.34.6",
                 "acorn": "^8.9.0",
                 "acorn-walk": "^8.2.0",
                 "cac": "^6.7.14",
-                "chai": "^4.3.7",
+                "chai": "^4.3.10",
                 "debug": "^4.3.4",
                 "local-pkg": "^0.4.3",
                 "magic-string": "^0.30.1",
@@ -6923,7 +7007,7 @@
                 "tinybench": "^2.5.0",
                 "tinypool": "^0.7.0",
                 "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0",
-                "vite-node": "0.34.4",
+                "vite-node": "0.34.6",
                 "why-is-node-running": "^2.2.2"
             },
             "bin": {
@@ -7307,26 +7391,26 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-            "integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ=="
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.20.tgz",
+            "integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw=="
         },
         "@babel/core": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.11.tgz",
-            "integrity": "sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.0.tgz",
+            "integrity": "sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==",
             "requires": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.22.10",
-                "@babel/generator": "^7.22.10",
-                "@babel/helper-compilation-targets": "^7.22.10",
-                "@babel/helper-module-transforms": "^7.22.9",
-                "@babel/helpers": "^7.22.11",
-                "@babel/parser": "^7.22.11",
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.11",
-                "@babel/types": "^7.22.11",
-                "convert-source-map": "^1.7.0",
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-compilation-targets": "^7.22.15",
+                "@babel/helper-module-transforms": "^7.23.0",
+                "@babel/helpers": "^7.23.0",
+                "@babel/parser": "^7.23.0",
+                "@babel/template": "^7.22.15",
+                "@babel/traverse": "^7.23.0",
+                "@babel/types": "^7.23.0",
+                "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
                 "json5": "^2.2.3",
@@ -7341,23 +7425,23 @@
             }
         },
         "@babel/generator": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
-            "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+            "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
             "requires": {
-                "@babel/types": "^7.22.10",
+                "@babel/types": "^7.23.0",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
-            "integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+            "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
             "requires": {
                 "@babel/compat-data": "^7.22.9",
-                "@babel/helper-validator-option": "^7.22.5",
+                "@babel/helper-validator-option": "^7.22.15",
                 "browserslist": "^4.21.9",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -7371,17 +7455,17 @@
             }
         },
         "@babel/helper-environment-visitor": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-            "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q=="
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA=="
         },
         "@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "requires": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
             }
         },
         "@babel/helper-hoist-variables": {
@@ -7393,23 +7477,23 @@
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-            "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+            "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
             "requires": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.22.15"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
-            "integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
+            "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
             "requires": {
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-module-imports": "^7.22.5",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-module-imports": "^7.22.15",
                 "@babel/helper-simple-access": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/helper-validator-identifier": "^7.22.5"
+                "@babel/helper-validator-identifier": "^7.22.20"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -7440,23 +7524,23 @@
             "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-            "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ=="
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
         },
         "@babel/helper-validator-option": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-            "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw=="
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+            "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA=="
         },
         "@babel/helpers": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.11.tgz",
-            "integrity": "sha512-vyOXC8PBWaGc5h7GMsNx68OH33cypkEDJCHvYVVgVbbxJDROYVtexSk0gK5iCF1xNjRIN2s8ai7hwkWDq5szWg==",
+            "version": "7.23.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.1.tgz",
+            "integrity": "sha512-chNpneuK18yW5Oxsr+t553UZzzAs3aZnFm4bxhebsNTeshrC95yA7l5yl7GBAG+JG1rF0F7zzD2EixK9mWSDoA==",
             "requires": {
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.11",
-                "@babel/types": "^7.22.11"
+                "@babel/template": "^7.22.15",
+                "@babel/traverse": "^7.23.0",
+                "@babel/types": "^7.23.0"
             }
         },
         "@babel/highlight": {
@@ -7470,9 +7554,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.22.13",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.13.tgz",
-            "integrity": "sha512-3l6+4YOvc9wx7VlCSw4yQfcBo01ECA8TicQfbnCPuCEpRQrf+gTUyGdxNw+pyTUyywp6JRD1w0YQs9TpBXYlkw=="
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+            "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw=="
         },
         "@babel/plugin-transform-react-jsx-self": {
             "version": "7.22.5",
@@ -7501,39 +7585,39 @@
             }
         },
         "@babel/template": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-            "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+            "version": "7.22.15",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
             "requires": {
-                "@babel/code-frame": "^7.22.5",
-                "@babel/parser": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/code-frame": "^7.22.13",
+                "@babel/parser": "^7.22.15",
+                "@babel/types": "^7.22.15"
             }
         },
         "@babel/traverse": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.11.tgz",
-            "integrity": "sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
+            "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
             "requires": {
-                "@babel/code-frame": "^7.22.10",
-                "@babel/generator": "^7.22.10",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
+                "@babel/code-frame": "^7.22.13",
+                "@babel/generator": "^7.23.0",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.11",
-                "@babel/types": "^7.22.11",
+                "@babel/parser": "^7.23.0",
+                "@babel/types": "^7.23.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
-            "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+            "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
             "requires": {
                 "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -7713,41 +7797,50 @@
             }
         },
         "@eslint/js": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
-            "integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
+            "version": "8.51.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
+            "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
             "dev": true
         },
         "@floating-ui/core": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
-            "integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+            "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+            "requires": {
+                "@floating-ui/utils": "^0.1.3"
+            }
         },
         "@floating-ui/dom": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.2.tgz",
-            "integrity": "sha512-VKmvHVatWnewmGGy+7Mdy4cTJX71Pli6v/Wjb5RQBuq5wjUYx+Ef+kRThi8qggZqDgD8CogCpqhRoVp3+yQk+g==",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+            "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
             "requires": {
-                "@floating-ui/core": "^1.3.1"
+                "@floating-ui/core": "^1.4.2",
+                "@floating-ui/utils": "^0.1.3"
             }
         },
         "@floating-ui/react": {
-            "version": "0.24.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.1.tgz",
-            "integrity": "sha512-qjCKUZDEz/4bnJmu4gn66TqsoX912/re8JGEi3pXazsphmyh327l0UpTgpBAT3WkNbnzAH7Adt3wKlLMNtfupw==",
+            "version": "0.25.4",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.25.4.tgz",
+            "integrity": "sha512-lWRQ/UiTvSIBxohn0/2HFHEmnmOVRjl7j6XcRJuLH0ls6f/9AyHMWVzkAJFuwx0n9gaEeCmg9VccCSCJzbEJig==",
             "requires": {
-                "@floating-ui/react-dom": "^2.0.0",
-                "aria-hidden": "^1.1.3",
+                "@floating-ui/react-dom": "^2.0.2",
+                "@floating-ui/utils": "^0.1.1",
                 "tabbable": "^6.0.1"
             }
         },
         "@floating-ui/react-dom": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-            "integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
+            "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
             "requires": {
-                "@floating-ui/dom": "^1.3.0"
+                "@floating-ui/dom": "^1.5.1"
             }
+        },
+        "@floating-ui/utils": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+            "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
         },
         "@humanwhocodes/config-array": {
             "version": "0.11.11",
@@ -7833,9 +7926,9 @@
             }
         },
         "@mswjs/data": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@mswjs/data/-/data-0.13.0.tgz",
-            "integrity": "sha512-0EeDQ5TF4O3nBQ6Y8/XY58YeTrKH5is/EuA0xf3o6sF3ftvhtLkSLSpFhd1dXASKzQprWzQDVxzaSYsmKPiXtg==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/@mswjs/data/-/data-0.14.0.tgz",
+            "integrity": "sha512-t51a8AWa0g19FPFOc3W4Lw0Lo39iWyTKy4fWJDWORGHjitJRepvbgs7ufm7O30r2ZaFSALhCUVyyocuii0dNqA==",
             "dev": true,
             "requires": {
                 "@types/lodash": "^4.14.172",
@@ -7901,23 +7994,23 @@
             "integrity": "sha512-R9rOWsIXPSbYVkZ2DOqJLeFiGBylSP7eiTMjqukro/46Lm7e0IOM9Xy8o7jr27IKBI3m9U0o0yxGFCd0CpgAGg=="
         },
         "@navikt/aksel-icons": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@navikt/aksel-icons/-/aksel-icons-5.5.0.tgz",
-            "integrity": "sha512-KKq28Ed4lYwnrESIyyOxnBGr7ef1RqTPZoLAJE1YXNGHfVMN/TEZCoZQlPialhZK8g36ngNgvtsZeEm5oCxoxQ=="
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@navikt/aksel-icons/-/aksel-icons-5.6.4.tgz",
+            "integrity": "sha512-O4BjhWaxORzpU/Y3AMSylSnPU0IC5rYZUi5N580h7HeEcEYXL+cBCaWqvzkQdK/NIuW6GMMpEABayw1xlUszYA=="
         },
         "@navikt/ds-css": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-5.5.0.tgz",
-            "integrity": "sha512-8QFCSyBY1B49L7w65xf+eBHSVjGHPFmhq5vrIijyeq7CbFGxH5ZQNkGZuQr5WE+cKhHk/ViOmA/FJUR++VWBCA=="
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-css/-/ds-css-5.6.4.tgz",
+            "integrity": "sha512-2nqwCxzyp59yLA51xnTKTyu1vyDj96P10kxfOo0jIMiNoM430fSx6ayqdd1x60H7HYlzj8wDtvB/tcPnGBHehg=="
         },
         "@navikt/ds-react": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-5.5.0.tgz",
-            "integrity": "sha512-sBX0q7MjkAVBYvE8mrNkb2YwF0Cx/TNLIjN96bnLOnqfHRB8CV2+lkYNR6u+c/8qOuPZXgyH25dqye9kMC4VdQ==",
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-react/-/ds-react-5.6.4.tgz",
+            "integrity": "sha512-R1PKdWpD2JN7pb7vES5lKgiBYgYJsi41g3OozsDdHUxuNQovXkhbTUQGVKNSWLrYwLOYcIbXf5ZqsfabtSLJyw==",
             "requires": {
-                "@floating-ui/react": "0.24.1",
-                "@navikt/aksel-icons": "^5.5.0",
-                "@navikt/ds-tokens": "^5.5.0",
+                "@floating-ui/react": "0.25.4",
+                "@navikt/aksel-icons": "^5.6.4",
+                "@navikt/ds-tokens": "^5.6.4",
                 "@radix-ui/react-tabs": "1.0.0",
                 "@radix-ui/react-toggle-group": "1.0.0",
                 "clsx": "^1.2.1",
@@ -7926,9 +8019,9 @@
             }
         },
         "@navikt/ds-tokens": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-5.5.0.tgz",
-            "integrity": "sha512-zV9TfGNjiRgpX1Ec11gK8BtgkiR+HN+qwjVbWt5NA6ux8xIQYdaFqLJWQa585vLl6DEOhwrlzb0FhT+KDvG3Rg=="
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@navikt/ds-tokens/-/ds-tokens-5.6.4.tgz",
+            "integrity": "sha512-yyLcVESKCAk6bUuL78uON2rbH35WDdWBNvUagf1pvTw9zeptgFuTho8IxpcpQHuY2NZLDZsn5RajloDg3C9GZw=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -8128,9 +8221,9 @@
             }
         },
         "@rollup/pluginutils": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.3.tgz",
-            "integrity": "sha512-hfllNN4a80rwNQ9QCxhxuHCGHMAvabXqxNdaChUSSadMre7t4iEUI6fFAhBOn/eIYTgYVhBv7vCLsAJ4u3lf3g==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+            "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
             "requires": {
                 "@types/estree": "^1.0.0",
                 "estree-walker": "^2.0.2",
@@ -8144,96 +8237,97 @@
             "dev": true
         },
         "@svgr/babel-plugin-add-jsx-attribute": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-7.0.0.tgz",
-            "integrity": "sha512-khWbXesWIP9v8HuKCl2NU2HNAyqpSQ/vkIl36Nbn4HIwEYSRWL0H7Gs6idJdha2DkpFDWlsqMELvoCE8lfFY6Q==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
+            "integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==",
             "requires": {}
         },
         "@svgr/babel-plugin-remove-jsx-attribute": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-7.0.0.tgz",
-            "integrity": "sha512-iiZaIvb3H/c7d3TH2HBeK91uI2rMhZNwnsIrvd7ZwGLkFw6mmunOCoVnjdYua662MqGFxlN9xTq4fv9hgR4VXQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-8.0.0.tgz",
+            "integrity": "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==",
             "requires": {}
         },
         "@svgr/babel-plugin-remove-jsx-empty-expression": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-7.0.0.tgz",
-            "integrity": "sha512-sQQmyo+qegBx8DfFc04PFmIO1FP1MHI1/QEpzcIcclo5OAISsOJPW76ZIs0bDyO/DBSJEa/tDa1W26pVtt0FRw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-8.0.0.tgz",
+            "integrity": "sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==",
             "requires": {}
         },
         "@svgr/babel-plugin-replace-jsx-attribute-value": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-7.0.0.tgz",
-            "integrity": "sha512-i6MaAqIZXDOJeikJuzocByBf8zO+meLwfQ/qMHIjCcvpnfvWf82PFvredEZElErB5glQFJa2KVKk8N2xV6tRRA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-8.0.0.tgz",
+            "integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==",
             "requires": {}
         },
         "@svgr/babel-plugin-svg-dynamic-title": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-7.0.0.tgz",
-            "integrity": "sha512-BoVSh6ge3SLLpKC0pmmN9DFlqgFy4NxNgdZNLPNJWBUU7TQpDWeBuyVuDW88iXydb5Cv0ReC+ffa5h3VrKfk1w==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-8.0.0.tgz",
+            "integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==",
             "requires": {}
         },
         "@svgr/babel-plugin-svg-em-dimensions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-7.0.0.tgz",
-            "integrity": "sha512-tNDcBa+hYn0gO+GkP/AuNKdVtMufVhU9fdzu+vUQsR18RIJ9RWe7h/pSBY338RO08wArntwbDk5WhQBmhf2PaA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-8.0.0.tgz",
+            "integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==",
             "requires": {}
         },
         "@svgr/babel-plugin-transform-react-native-svg": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-7.0.0.tgz",
-            "integrity": "sha512-qw54u8ljCJYL2KtBOjI5z7Nzg8LnSvQOP5hPKj77H4VQL4+HdKbAT5pnkkZLmHKYwzsIHSYKXxHouD8zZamCFQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-8.1.0.tgz",
+            "integrity": "sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==",
             "requires": {}
         },
         "@svgr/babel-plugin-transform-svg-component": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-7.0.0.tgz",
-            "integrity": "sha512-CcFECkDj98daOg9jE3Bh3uyD9kzevCAnZ+UtzG6+BQG/jOQ2OA3jHnX6iG4G1MCJkUQFnUvEv33NvQfqrb/F3A==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-8.0.0.tgz",
+            "integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==",
             "requires": {}
         },
         "@svgr/babel-preset": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-7.0.0.tgz",
-            "integrity": "sha512-EX/NHeFa30j5UjldQGVQikuuQNHUdGmbh9kEpBKofGUtF0GUPJ4T4rhoYiqDAOmBOxojyot36JIFiDUHUK1ilQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-8.1.0.tgz",
+            "integrity": "sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==",
             "requires": {
-                "@svgr/babel-plugin-add-jsx-attribute": "^7.0.0",
-                "@svgr/babel-plugin-remove-jsx-attribute": "^7.0.0",
-                "@svgr/babel-plugin-remove-jsx-empty-expression": "^7.0.0",
-                "@svgr/babel-plugin-replace-jsx-attribute-value": "^7.0.0",
-                "@svgr/babel-plugin-svg-dynamic-title": "^7.0.0",
-                "@svgr/babel-plugin-svg-em-dimensions": "^7.0.0",
-                "@svgr/babel-plugin-transform-react-native-svg": "^7.0.0",
-                "@svgr/babel-plugin-transform-svg-component": "^7.0.0"
+                "@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
+                "@svgr/babel-plugin-remove-jsx-attribute": "8.0.0",
+                "@svgr/babel-plugin-remove-jsx-empty-expression": "8.0.0",
+                "@svgr/babel-plugin-replace-jsx-attribute-value": "8.0.0",
+                "@svgr/babel-plugin-svg-dynamic-title": "8.0.0",
+                "@svgr/babel-plugin-svg-em-dimensions": "8.0.0",
+                "@svgr/babel-plugin-transform-react-native-svg": "8.1.0",
+                "@svgr/babel-plugin-transform-svg-component": "8.0.0"
             }
         },
         "@svgr/core": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/core/-/core-7.0.0.tgz",
-            "integrity": "sha512-ztAoxkaKhRVloa3XydohgQQCb0/8x9T63yXovpmHzKMkHO6pkjdsIAWKOS4bE95P/2quVh1NtjSKlMRNzSBffw==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
+            "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "requires": {
                 "@babel/core": "^7.21.3",
-                "@svgr/babel-preset": "^7.0.0",
+                "@svgr/babel-preset": "8.1.0",
                 "camelcase": "^6.2.0",
-                "cosmiconfig": "^8.1.3"
+                "cosmiconfig": "^8.1.3",
+                "snake-case": "^3.0.4"
             }
         },
         "@svgr/hast-util-to-babel-ast": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-7.0.0.tgz",
-            "integrity": "sha512-42Ej9sDDEmsJKjrfQ1PHmiDiHagh/u9AHO9QWbeNx4KmD9yS5d1XHmXUNINfUcykAU+4431Cn+k6Vn5mWBYimQ==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-8.0.0.tgz",
+            "integrity": "sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==",
             "requires": {
                 "@babel/types": "^7.21.3",
                 "entities": "^4.4.0"
             }
         },
         "@svgr/plugin-jsx": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-7.0.0.tgz",
-            "integrity": "sha512-SWlTpPQmBUtLKxXWgpv8syzqIU8XgFRvyhfkam2So8b3BE0OS0HPe5UfmlJ2KIC+a7dpuuYovPR2WAQuSyMoPw==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-8.1.0.tgz",
+            "integrity": "sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==",
             "requires": {
                 "@babel/core": "^7.21.3",
-                "@svgr/babel-preset": "^7.0.0",
-                "@svgr/hast-util-to-babel-ast": "^7.0.0",
+                "@svgr/babel-preset": "8.1.0",
+                "@svgr/hast-util-to-babel-ast": "8.0.0",
                 "svg-parser": "^2.0.4"
             }
         },
@@ -8352,6 +8446,47 @@
             "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
             "dev": true
         },
+        "@types/babel__core": {
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.2.tgz",
+            "integrity": "sha512-pNpr1T1xLUc2l3xJKuPtsEky3ybxN3m4fJkknfIpTCTfIZCDW57oAg+EfCgIIp2rvCe0Wn++/FfodDS4YXxBwA==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "@types/babel__generator": {
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.5.tgz",
+            "integrity": "sha512-h9yIuWbJKdOPLJTbmSpPzkF67e659PbQDba7ifWm5BJ8xTv+sDmS7rFmywkWOvXedGTivCdeGSIIX8WLcRTz8w==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__template": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.2.tgz",
+            "integrity": "sha512-/AVzPICMhMOMYoSx9MoKpGDKdBRsIXMNByh1PXSZoa+v6ZoLa8xxtsT/uLQ/NJm0XVAWl/BvId4MlDeXJaeIZQ==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@types/babel__traverse": {
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.2.tgz",
+            "integrity": "sha512-ojlGK1Hsfce93J0+kn3H5R73elidKUaZonirN33GSmgTUMpzI/MIFfSpF3haANe3G1bEBS9/9/QEqwTzwqFsKw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.20.7"
+            }
+        },
         "@types/chai": {
             "version": "4.3.5",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
@@ -8383,9 +8518,9 @@
             }
         },
         "@types/estree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-            "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
+            "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA=="
         },
         "@types/js-levenshtein": {
             "version": "1.1.1",
@@ -8394,9 +8529,9 @@
             "dev": true
         },
         "@types/json-schema": {
-            "version": "7.0.12",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-            "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+            "version": "7.0.13",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
+            "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
             "dev": true
         },
         "@types/lodash": {
@@ -8436,9 +8571,9 @@
             "devOptional": true
         },
         "@types/react": {
-            "version": "18.2.21",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
-            "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
+            "version": "18.2.25",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.25.tgz",
+            "integrity": "sha512-24xqse6+VByVLIr+xWaQ9muX1B4bXJKXBbjszbld/UEDslGLY53+ZucF44HCmLbMPejTzGG9XgR+3m2/Wqu1kw==",
             "devOptional": true,
             "requires": {
                 "@types/prop-types": "*",
@@ -8447,9 +8582,9 @@
             }
         },
         "@types/react-dom": {
-            "version": "18.2.7",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
-            "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+            "version": "18.2.11",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.11.tgz",
+            "integrity": "sha512-zq6Dy0EiCuF9pWFW6I6k6W2LdpUixLE4P6XjXU1QHLfak3GPACQfLwEuHzY5pOYa4hzj1d0GxX/P141aFjZsyg==",
             "dev": true,
             "requires": {
                 "@types/react": "*"
@@ -8462,9 +8597,9 @@
             "devOptional": true
         },
         "@types/semver": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.2.tgz",
-            "integrity": "sha512-7aqorHYgdNO4DM36stTiGO3DvKoex9TQRwsJU6vMaFGyqpBA1MNZkz+PG3gaNUPpTAOYhT1WR7M1JyA3fbS9Cw==",
+            "version": "7.5.3",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
+            "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
             "dev": true
         },
         "@types/set-cookie-parser": {
@@ -8483,16 +8618,16 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.0.tgz",
-            "integrity": "sha512-gUqtknHm0TDs1LhY12K2NA3Rmlmp88jK9Tx8vGZMfHeNMLE3GH2e9TRub+y+SOjuYgtOmok+wt1AyDPZqxbNag==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.4.tgz",
+            "integrity": "sha512-DAbgDXwtX+pDkAHwiGhqP3zWUGpW49B7eqmgpPtg+BKJXwdct79ut9+ifqOFPJGClGKSHXn2PTBatCnldJRUoA==",
             "dev": true,
             "requires": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.7.0",
-                "@typescript-eslint/type-utils": "6.7.0",
-                "@typescript-eslint/utils": "6.7.0",
-                "@typescript-eslint/visitor-keys": "6.7.0",
+                "@typescript-eslint/scope-manager": "6.7.4",
+                "@typescript-eslint/type-utils": "6.7.4",
+                "@typescript-eslint/utils": "6.7.4",
+                "@typescript-eslint/visitor-keys": "6.7.4",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
@@ -8502,54 +8637,54 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.0.tgz",
-            "integrity": "sha512-jZKYwqNpNm5kzPVP5z1JXAuxjtl2uG+5NpaMocFPTNC2EdYIgbXIPImObOkhbONxtFTTdoZstLZefbaK+wXZng==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.4.tgz",
+            "integrity": "sha512-I5zVZFY+cw4IMZUeNCU7Sh2PO5O57F7Lr0uyhgCJmhN/BuTlnc55KxPonR4+EM3GBdfiCyGZye6DgMjtubQkmA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "6.7.0",
-                "@typescript-eslint/types": "6.7.0",
-                "@typescript-eslint/typescript-estree": "6.7.0",
-                "@typescript-eslint/visitor-keys": "6.7.0",
+                "@typescript-eslint/scope-manager": "6.7.4",
+                "@typescript-eslint/types": "6.7.4",
+                "@typescript-eslint/typescript-estree": "6.7.4",
+                "@typescript-eslint/visitor-keys": "6.7.4",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.0.tgz",
-            "integrity": "sha512-lAT1Uau20lQyjoLUQ5FUMSX/dS07qux9rYd5FGzKz/Kf8W8ccuvMyldb8hadHdK/qOI7aikvQWqulnEq2nCEYA==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.4.tgz",
+            "integrity": "sha512-SdGqSLUPTXAXi7c3Ob7peAGVnmMoGzZ361VswK2Mqf8UOYcODiYvs8rs5ILqEdfvX1lE7wEZbLyELCW+Yrql1A==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "6.7.0",
-                "@typescript-eslint/visitor-keys": "6.7.0"
+                "@typescript-eslint/types": "6.7.4",
+                "@typescript-eslint/visitor-keys": "6.7.4"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.0.tgz",
-            "integrity": "sha512-f/QabJgDAlpSz3qduCyQT0Fw7hHpmhOzY/Rv6zO3yO+HVIdPfIWhrQoAyG+uZVtWAIS85zAyzgAFfyEr+MgBpg==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.4.tgz",
+            "integrity": "sha512-n+g3zi1QzpcAdHFP9KQF+rEFxMb2KxtnJGID3teA/nxKHOVi3ylKovaqEzGBbVY2pBttU6z85gp0D00ufLzViQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/typescript-estree": "6.7.0",
-                "@typescript-eslint/utils": "6.7.0",
+                "@typescript-eslint/typescript-estree": "6.7.4",
+                "@typescript-eslint/utils": "6.7.4",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             }
         },
         "@typescript-eslint/types": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.0.tgz",
-            "integrity": "sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.4.tgz",
+            "integrity": "sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.0.tgz",
-            "integrity": "sha512-dPvkXj3n6e9yd/0LfojNU8VMUGHWiLuBZvbM6V6QYD+2qxqInE7J+J/ieY2iGwR9ivf/R/haWGkIj04WVUeiSQ==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.4.tgz",
+            "integrity": "sha512-ty8b5qHKatlNYd9vmpHooQz3Vki3gG+3PchmtsA4TgrZBKWHNjWfkQid7K7xQogBqqc7/BhGazxMD5vr6Ha+iQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "6.7.0",
-                "@typescript-eslint/visitor-keys": "6.7.0",
+                "@typescript-eslint/types": "6.7.4",
+                "@typescript-eslint/visitor-keys": "6.7.4",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -8558,60 +8693,61 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.0.tgz",
-            "integrity": "sha512-MfCq3cM0vh2slSikQYqK2Gq52gvOhe57vD2RM3V4gQRZYX4rDPnKLu5p6cm89+LJiGlwEXU8hkYxhqqEC/V3qA==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.4.tgz",
+            "integrity": "sha512-PRQAs+HUn85Qdk+khAxsVV+oULy3VkbH3hQ8hxLRJXWBEd7iI+GbQxH5SEUSH7kbEoTp6oT1bOwyga24ELALTA==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.7.0",
-                "@typescript-eslint/types": "6.7.0",
-                "@typescript-eslint/typescript-estree": "6.7.0",
+                "@typescript-eslint/scope-manager": "6.7.4",
+                "@typescript-eslint/types": "6.7.4",
+                "@typescript-eslint/typescript-estree": "6.7.4",
                 "semver": "^7.5.4"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "6.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.0.tgz",
-            "integrity": "sha512-/C1RVgKFDmGMcVGeD8HjKv2bd72oI1KxQDeY8uc66gw9R0OK0eMq48cA+jv9/2Ag6cdrsUGySm1yzYmfz0hxwQ==",
+            "version": "6.7.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.4.tgz",
+            "integrity": "sha512-pOW37DUhlTZbvph50x5zZCkFn3xzwkGtNoJHzIM3svpiSkJzwOYr/kVBaXmf+RAQiUDs1AHEZVNPg6UJCJpwRA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "6.7.0",
+                "@typescript-eslint/types": "6.7.4",
                 "eslint-visitor-keys": "^3.4.1"
             }
         },
         "@vitejs/plugin-react": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.0.4.tgz",
-            "integrity": "sha512-7wU921ABnNYkETiMaZy7XqpueMnpu5VxvVps13MjmCo+utBdD79sZzrApHawHtVX66cCJQQTXFcjH0y9dSUK8g==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.1.0.tgz",
+            "integrity": "sha512-rM0SqazU9iqPUraQ2JlIvReeaxOoRj6n+PzB1C0cBzIbd8qP336nC39/R9yPi3wVcah7E7j/kdU1uCUqMEU4OQ==",
             "dev": true,
             "requires": {
-                "@babel/core": "^7.22.9",
+                "@babel/core": "^7.22.20",
                 "@babel/plugin-transform-react-jsx-self": "^7.22.5",
                 "@babel/plugin-transform-react-jsx-source": "^7.22.5",
+                "@types/babel__core": "^7.20.2",
                 "react-refresh": "^0.14.0"
             }
         },
         "@vitest/expect": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.4.tgz",
-            "integrity": "sha512-XlMKX8HyYUqB8dsY8Xxrc64J2Qs9pKMt2Z8vFTL4mBWXJsg4yoALHzJfDWi8h5nkO4Zua4zjqtapQ/IluVkSnA==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.6.tgz",
+            "integrity": "sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==",
             "dev": true,
             "requires": {
-                "@vitest/spy": "0.34.4",
-                "@vitest/utils": "0.34.4",
-                "chai": "^4.3.7"
+                "@vitest/spy": "0.34.6",
+                "@vitest/utils": "0.34.6",
+                "chai": "^4.3.10"
             }
         },
         "@vitest/runner": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.4.tgz",
-            "integrity": "sha512-hwwdB1StERqUls8oV8YcpmTIpVeJMe4WgYuDongVzixl5hlYLT2G8afhcdADeDeqCaAmZcSgLTLtqkjPQF7x+w==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.6.tgz",
+            "integrity": "sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==",
             "dev": true,
             "requires": {
-                "@vitest/utils": "0.34.4",
+                "@vitest/utils": "0.34.6",
                 "p-limit": "^4.0.0",
                 "pathe": "^1.1.1"
             },
@@ -8634,9 +8770,9 @@
             }
         },
         "@vitest/snapshot": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.4.tgz",
-            "integrity": "sha512-GCsh4coc3YUSL/o+BPUo7lHQbzpdttTxL6f4q0jRx2qVGoYz/cyTRDJHbnwks6TILi6560bVWoBpYC10PuTLHw==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.6.tgz",
+            "integrity": "sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==",
             "dev": true,
             "requires": {
                 "magic-string": "^0.30.1",
@@ -8645,18 +8781,18 @@
             }
         },
         "@vitest/spy": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.4.tgz",
-            "integrity": "sha512-PNU+fd7DUPgA3Ya924b1qKuQkonAW6hL7YUjkON3wmBwSTIlhOSpy04SJ0NrRsEbrXgMMj6Morh04BMf8k+w0g==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.6.tgz",
+            "integrity": "sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==",
             "dev": true,
             "requires": {
                 "tinyspy": "^2.1.1"
             }
         },
         "@vitest/utils": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.4.tgz",
-            "integrity": "sha512-yR2+5CHhp/K4ySY0Qtd+CAL9f5Yh1aXrKfAT42bq6CtlGPh92jIDDDSg7ydlRow1CP+dys4TrOrbELOyNInHSg==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.6.tgz",
+            "integrity": "sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==",
             "dev": true,
             "requires": {
                 "diff-sequences": "^29.4.3",
@@ -8768,21 +8904,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "aria-hidden": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
-            "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
-            "requires": {
-                "tslib": "^2.0.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
-                }
-            }
         },
         "aria-query": {
             "version": "5.1.3",
@@ -8948,14 +9069,14 @@
             }
         },
         "browserslist": {
-            "version": "4.21.10",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-            "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+            "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
             "requires": {
-                "caniuse-lite": "^1.0.30001517",
-                "electron-to-chromium": "^1.4.477",
+                "caniuse-lite": "^1.0.30001541",
+                "electron-to-chromium": "^1.4.535",
                 "node-releases": "^2.0.13",
-                "update-browserslist-db": "^1.0.11"
+                "update-browserslist-db": "^1.0.13"
             }
         },
         "buffer": {
@@ -8995,23 +9116,23 @@
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
         },
         "caniuse-lite": {
-            "version": "1.0.30001524",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
-            "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA=="
+            "version": "1.0.30001546",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001546.tgz",
+            "integrity": "sha512-zvtSJwuQFpewSyRrI3AsftF6rM0X80mZkChIt1spBGEvRglCrjTniXvinc8JKRoqTwXAgvqTImaN9igfSMtUBw=="
         },
         "chai": {
-            "version": "4.3.8",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.8.tgz",
-            "integrity": "sha512-vX4YvVVtxlfSZ2VecZgFUTU5qPCYsobVI2O9FmwEXBhDigYGQA6jRXCycIs1yJnnWbZ6/+a2zNIF5DfVCcJBFQ==",
+            "version": "4.3.10",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
+            "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
             "dev": true,
             "requires": {
                 "assertion-error": "^1.1.0",
-                "check-error": "^1.0.2",
-                "deep-eql": "^4.1.2",
-                "get-func-name": "^2.0.0",
-                "loupe": "^2.3.1",
+                "check-error": "^1.0.3",
+                "deep-eql": "^4.1.3",
+                "get-func-name": "^2.0.2",
+                "loupe": "^2.3.6",
                 "pathval": "^1.1.1",
-                "type-detect": "^4.0.5"
+                "type-detect": "^4.0.8"
             }
         },
         "chalk": {
@@ -9037,10 +9158,13 @@
             "dev": true
         },
         "check-error": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-            "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-            "dev": true
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+            "dev": true,
+            "requires": {
+                "get-func-name": "^2.0.2"
+            }
         },
         "chokidar": {
             "version": "3.5.3",
@@ -9152,9 +9276,9 @@
             "requires": {}
         },
         "convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
         },
         "cookie": {
             "version": "0.4.2",
@@ -9163,13 +9287,13 @@
             "dev": true
         },
         "cosmiconfig": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-            "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+            "version": "8.3.6",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+            "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
             "requires": {
-                "import-fresh": "^3.2.1",
+                "import-fresh": "^3.3.0",
                 "js-yaml": "^4.1.0",
-                "parse-json": "^5.0.0",
+                "parse-json": "^5.2.0",
                 "path-type": "^4.0.0"
             }
         },
@@ -9387,10 +9511,19 @@
                 }
             }
         },
+        "dot-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+            "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+            "requires": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
         "electron-to-chromium": {
-            "version": "1.4.504",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.504.tgz",
-            "integrity": "sha512-cSMwIAd8yUh54VwitVRVvHK66QqHWE39C3DRj8SWiXitEpVSY3wNPD9y1pxQtLIi4w3UdzF9klLsmuPshz09DQ=="
+            "version": "1.4.544",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.544.tgz",
+            "integrity": "sha512-54z7squS1FyFRSUqq/knOFSptjjogLZXbKcYk3B0qkE1KZzvqASwRZnY2KzZQJqIYLVD38XZeoiMRflYSwyO4w=="
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -9546,15 +9679,15 @@
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "eslint": {
-            "version": "8.49.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
-            "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
+            "version": "8.51.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
+            "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.2",
-                "@eslint/js": "8.49.0",
+                "@eslint/js": "8.51.0",
                 "@humanwhocodes/config-array": "^0.11.11",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -9959,9 +10092,9 @@
             "dev": true
         },
         "get-func-name": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-            "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
             "dev": true
         },
         "get-intrinsic": {
@@ -10053,9 +10186,9 @@
             "dev": true
         },
         "graphql": {
-            "version": "16.7.1",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz",
-            "integrity": "sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==",
+            "version": "16.8.1",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+            "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
             "dev": true
         },
         "has": {
@@ -10793,6 +10926,14 @@
                 "get-func-name": "^2.0.0"
             }
         },
+        "lower-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+            "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+            "requires": {
+                "tslib": "^2.0.3"
+            }
+        },
         "lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -10808,9 +10949,9 @@
             "dev": true
         },
         "magic-string": {
-            "version": "0.30.3",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
-            "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
+            "version": "0.30.4",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.4.tgz",
+            "integrity": "sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==",
             "dev": true,
             "requires": {
                 "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -10891,9 +11032,9 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "msw": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.1.tgz",
-            "integrity": "sha512-GhP5lHSTXNlZb9EaKgPRJ01YAnVXwzkvnTzRn4W8fxU2DXuJrRO+Nb6OHdYqB4fCkwSNpIJH9JkON5Y6rHqJMQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.2.tgz",
+            "integrity": "sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==",
             "dev": true,
             "requires": {
                 "@mswjs/cookies": "^0.2.2",
@@ -10904,7 +11045,7 @@
                 "chalk": "^4.1.1",
                 "chokidar": "^3.4.2",
                 "cookie": "^0.4.2",
-                "graphql": "^15.0.0 || ^16.0.0",
+                "graphql": "^16.8.1",
                 "headers-polyfill": "3.2.5",
                 "inquirer": "^8.2.0",
                 "is-node-process": "^1.2.0",
@@ -10990,6 +11131,15 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
+        },
+        "no-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+            "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+            "requires": {
+                "lower-case": "^2.0.2",
+                "tslib": "^2.0.3"
+            }
         },
         "node-fetch": {
             "version": "2.6.11",
@@ -11333,9 +11483,9 @@
             "dev": true
         },
         "pretty-format": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
-            "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "dev": true,
             "requires": {
                 "@jest/schemas": "^29.6.3",
@@ -11524,14 +11674,6 @@
             "dev": true,
             "requires": {
                 "tslib": "^2.1.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.5.3",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-                    "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-                    "dev": true
-                }
             }
         },
         "safe-array-concat": {
@@ -11662,6 +11804,15 @@
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
         },
+        "snake-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+            "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+            "requires": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
         "source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -11785,9 +11936,9 @@
             "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
         },
         "swr": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.2.tgz",
-            "integrity": "sha512-CbR41AoMD4TQBQw9ic3GTXspgfM9Y8Mdhb5Ob4uIKXhWqnRLItwA5fpGvB7SmSw3+zEjb0PdhiEumtUvYoQ+bQ==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.4.tgz",
+            "integrity": "sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==",
             "requires": {
                 "client-only": "^0.0.1",
                 "use-sync-external-store": "^1.2.0"
@@ -11800,9 +11951,9 @@
             "dev": true
         },
         "tabbable": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
-            "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ=="
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
         },
         "text-table": {
             "version": "0.2.0",
@@ -11829,9 +11980,9 @@
             "dev": true
         },
         "tinyspy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.1.1.tgz",
-            "integrity": "sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.0.tgz",
+            "integrity": "sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==",
             "dev": true
         },
         "tmp": {
@@ -11881,6 +12032,11 @@
             "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
             "dev": true,
             "requires": {}
+        },
+        "tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "type-check": {
             "version": "0.4.0",
@@ -11954,12 +12110,12 @@
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
             "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-            "dev": true
+            "devOptional": true
         },
         "ufo": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.0.tgz",
-            "integrity": "sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.1.tgz",
+            "integrity": "sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==",
             "dev": true
         },
         "unbox-primitive": {
@@ -11981,9 +12137,9 @@
             "dev": true
         },
         "update-browserslist-db": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-            "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
             "requires": {
                 "escalade": "^3.1.1",
                 "picocolors": "^1.0.0"
@@ -12040,9 +12196,9 @@
             "dev": true
         },
         "vite": {
-            "version": "4.4.9",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-            "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+            "version": "4.4.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
+            "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
             "requires": {
                 "esbuild": "^0.18.10",
                 "fsevents": "~2.3.2",
@@ -12051,9 +12207,9 @@
             }
         },
         "vite-node": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.4.tgz",
-            "integrity": "sha512-ho8HtiLc+nsmbwZMw8SlghESEE3KxJNp04F/jPUCLVvaURwt0d+r9LxEqCX5hvrrOQ0GSyxbYr5ZfRYhQ0yVKQ==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.6.tgz",
+            "integrity": "sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==",
             "dev": true,
             "requires": {
                 "cac": "^6.7.14",
@@ -12061,37 +12217,37 @@
                 "mlly": "^1.4.0",
                 "pathe": "^1.1.1",
                 "picocolors": "^1.0.0",
-                "vite": "^3.0.0 || ^4.0.0"
+                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
             }
         },
         "vite-plugin-svgr": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-3.2.0.tgz",
-            "integrity": "sha512-Uvq6niTvhqJU6ga78qLKBFJSDvxWhOnyfQSoKpDPMAGxJPo5S3+9hyjExE5YDj6Lpa4uaLkGc1cBgxXov+LjSw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-4.1.0.tgz",
+            "integrity": "sha512-v7Qic+FWmCChgQNGSI4V8X63OEYsdUoLt66iqIcHozq9bfK/Dwmr0V+LBy1NE8CE98Y8HouEBJ+pto4AMfN5xw==",
             "requires": {
-                "@rollup/pluginutils": "^5.0.2",
-                "@svgr/core": "^7.0.0",
-                "@svgr/plugin-jsx": "^7.0.0"
+                "@rollup/pluginutils": "^5.0.4",
+                "@svgr/core": "^8.1.0",
+                "@svgr/plugin-jsx": "^8.1.0"
             }
         },
         "vitest": {
-            "version": "0.34.4",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.4.tgz",
-            "integrity": "sha512-SE/laOsB6995QlbSE6BtkpXDeVNLJc1u2LHRG/OpnN4RsRzM3GQm4nm3PQCK5OBtrsUqnhzLdnT7se3aeNGdlw==",
+            "version": "0.34.6",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.6.tgz",
+            "integrity": "sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==",
             "dev": true,
             "requires": {
                 "@types/chai": "^4.3.5",
                 "@types/chai-subset": "^1.3.3",
                 "@types/node": "*",
-                "@vitest/expect": "0.34.4",
-                "@vitest/runner": "0.34.4",
-                "@vitest/snapshot": "0.34.4",
-                "@vitest/spy": "0.34.4",
-                "@vitest/utils": "0.34.4",
+                "@vitest/expect": "0.34.6",
+                "@vitest/runner": "0.34.6",
+                "@vitest/snapshot": "0.34.6",
+                "@vitest/spy": "0.34.6",
+                "@vitest/utils": "0.34.6",
                 "acorn": "^8.9.0",
                 "acorn-walk": "^8.2.0",
                 "cac": "^6.7.14",
-                "chai": "^4.3.7",
+                "chai": "^4.3.10",
                 "debug": "^4.3.4",
                 "local-pkg": "^0.4.3",
                 "magic-string": "^0.30.1",
@@ -12102,7 +12258,7 @@
                 "tinybench": "^2.5.0",
                 "tinypool": "^0.7.0",
                 "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0",
-                "vite-node": "0.34.4",
+                "vite-node": "0.34.6",
                 "why-is-node-running": "^2.2.2"
             }
         },

--- a/package.json
+++ b/package.json
@@ -17,33 +17,33 @@
     },
     "dependencies": {
         "@mswjs/storage": "^0.1.0",
-        "@navikt/aksel-icons": "5.5.0",
-        "@navikt/ds-css": "5.5.0",
-        "@navikt/ds-react": "5.5.0",
+        "@navikt/aksel-icons": "5.6.4",
+        "@navikt/ds-css": "5.6.4",
+        "@navikt/ds-react": "5.6.4",
         "constate": "^3.3.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "swr": "2.2.2",
-        "vite-plugin-svgr": "^3.2.0"
+        "swr": "2.2.4",
+        "vite-plugin-svgr": "4.1.0"
     },
     "devDependencies": {
-        "@mswjs/data": "^0.13.0",
+        "@mswjs/data": "0.14.0",
         "@testing-library/react": "^14.0.0",
-        "@types/react": "18.2.21",
-        "@types/react-dom": "18.2.7",
-        "@typescript-eslint/eslint-plugin": "6.7.0",
-        "@typescript-eslint/parser": "6.7.0",
-        "@vitejs/plugin-react": "4.0.4",
-        "eslint": "8.49.0",
+        "@types/react": "18.2.25",
+        "@types/react-dom": "18.2.11",
+        "@typescript-eslint/eslint-plugin": "6.7.4",
+        "@typescript-eslint/parser": "6.7.4",
+        "@vitejs/plugin-react": "4.1.0",
+        "eslint": "8.51.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "0.4.3",
         "jsdom": "^22.1.0",
-        "msw": "1.3.1",
+        "msw": "1.3.2",
         "prettier": "3.0.3",
         "typescript": "5.2.2",
-        "vite": "4.4.9",
-        "vitest": "0.34.4"
+        "vite": "4.4.11",
+        "vitest": "0.34.6"
     },
     "msw": {
         "workerDirectory": "public"

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.3.1).
+ * Mock Service Worker (1.3.2).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { sendOverblikkFilter, useOverblikkFilter } from './data/api/fetch';
 import { SWRConfig } from 'swr';
 import TilToppenKnapp from './components/felles/til-toppen-knapp';
 import { trackAmplitude } from './amplitude/amplitude';
+import '../index.css';
 
 export interface AppProps {
     fnr?: string;
@@ -198,7 +199,12 @@ const App = (props: AppProps) => {
 
                         <section className="main_grid">
                             {valgteInformasjonsbokser.map((valgtInformasjonsboks) => (
-                                <Panel border className="info_panel" key={valgtInformasjonsboks}>
+                                <Panel
+                                    border
+                                    className="info_panel"
+                                    key={valgtInformasjonsboks}
+                                    id={`${valgtInformasjonsboks}-panel`}
+                                >
                                     <Heading spacing level="2" size="medium" className="panel_header">
                                         {valgtInformasjonsboks}
                                     </Heading>

--- a/src/components/cv/andre-godkjenninger.tsx
+++ b/src/components/cv/andre-godkjenninger.tsx
@@ -4,7 +4,7 @@ import { formaterDato } from '../../utils/formater';
 import { safeMap } from '../../utils';
 import { BodyShort } from '@navikt/ds-react';
 import EMDASH from '../../utils/emdash';
-import { ReactComponent as Andreikon } from './ikoner/andre-godkjenninger.svg';
+import Andreikon from './ikoner/andre-godkjenninger.svg?react';
 import '../fellesStyling.css';
 
 const AndreGodkjenninger = ({ andreGodkjenninger }: Pick<ArenaPerson, 'andreGodkjenninger'>) => {

--- a/src/components/cv/annen-erfaring.tsx
+++ b/src/components/cv/annen-erfaring.tsx
@@ -3,7 +3,7 @@ import Informasjonsbolk from '../felles/informasjonsbolk';
 import { formaterDato } from '../../utils/formater';
 import { safeMap, safeSort } from '../../utils';
 import { BodyShort } from '@navikt/ds-react';
-import { ReactComponent as Erfaringsikon } from './ikoner/annen-erfaring.svg';
+import Erfaringsikon from './ikoner/annen-erfaring.svg?react';
 
 const AnnenErfaring = ({ annenErfaring }: Pick<ArenaPerson, 'annenErfaring'>) => {
     const sortedErfaringer = annenErfaring.sort((a, b) => safeSort(b.tilDato, a.tilDato));

--- a/src/components/cv/arbeidserfaring.tsx
+++ b/src/components/cv/arbeidserfaring.tsx
@@ -28,7 +28,11 @@ const Arbeidserfaring = ({ arbeidserfaring }: Pick<ArenaPerson, 'arbeidserfaring
     ));
 
     return (
-        <Informasjonsbolk header="Arbeidsforhold" icon={<Buldings3Icon aria-hidden="true" />} headerTypo="ingress">
+        <Informasjonsbolk
+            header="Arbeidsforhold"
+            icon={<Buldings3Icon aria-hidden="true" id="arbeidsforholdikon" />}
+            headerTypo="ingress"
+        >
             {erfaringer}
         </Informasjonsbolk>
     );

--- a/src/components/cv/fagdokumentasjoner.tsx
+++ b/src/components/cv/fagdokumentasjoner.tsx
@@ -2,7 +2,7 @@ import { ArenaPerson, Fagdokumentasjon, FagdokumentType } from '../../data/api/d
 import EMDASH from '../../utils/emdash';
 import Informasjonsbolk from '../felles/informasjonsbolk';
 import { BodyShort } from '@navikt/ds-react';
-import { ReactComponent as Fagbrevikon } from './ikoner/fagbrev.svg';
+import Fagbrevikon from './ikoner/fagbrev.svg?react';
 
 const fagdokumentTypeTilTekst = (fagdokumentType: FagdokumentType): string => {
     switch (fagdokumentType) {

--- a/src/components/cv/forerkort.tsx
+++ b/src/components/cv/forerkort.tsx
@@ -2,7 +2,7 @@ import { ArenaPerson } from '../../data/api/datatyper/arenaperson';
 import Informasjonsbolk from '../felles/informasjonsbolk';
 import { safeMap } from '../../utils';
 import { BodyShort } from '@navikt/ds-react';
-import { ReactComponent as Forerkortikon } from './ikoner/forerkort.svg';
+import Forerkortikon from './ikoner/forerkort.svg?react';
 import EMDASH from '../../utils/emdash';
 
 const Forerkort = ({ forerkort }: Pick<ArenaPerson, 'forerkort'>) => {

--- a/src/components/cv/godkjenninger.tsx
+++ b/src/components/cv/godkjenninger.tsx
@@ -4,7 +4,7 @@ import { formaterDato } from '../../utils/formater';
 import { safeMap } from '../../utils';
 import { BodyShort } from '@navikt/ds-react';
 import EMDASH from '../../utils/emdash';
-import { ReactComponent as OffentligeGodkjenningerIkon } from './ikoner/offentlige-godkjenninger.svg';
+import OffentligeGodkjenningerikon from './ikoner/offentlige-godkjenninger.svg?react';
 
 const Godkjenninger = ({ godkjenninger }: Pick<ArenaPerson, 'godkjenninger'>) => {
     const godkjenningListe = safeMap(godkjenninger, (godkjenning, index) => (
@@ -28,7 +28,7 @@ const Godkjenninger = ({ godkjenninger }: Pick<ArenaPerson, 'godkjenninger'>) =>
     return (
         <Informasjonsbolk
             header="Offentlige godkjenninger"
-            icon={<OffentligeGodkjenningerIkon aria-hidden="true" />}
+            icon={<OffentligeGodkjenningerikon aria-hidden="true" />}
             headerTypo="ingress"
         >
             {godkjenningListe}

--- a/src/components/cv/kompetanser.tsx
+++ b/src/components/cv/kompetanser.tsx
@@ -3,7 +3,7 @@ import { Jobbprofil } from '../../data/api/datatyper/arenaperson';
 import EMDASH from '../../utils/emdash';
 import Informasjonsbolk from '../felles/informasjonsbolk';
 import ListItem from '@navikt/ds-react/esm/list/ListItem';
-import { ReactComponent as Kompetanserikon } from './ikoner/kompetanser.svg';
+import Kompetanserikon from './ikoner/kompetanser.svg?react';
 
 const Kompetanser = ({ kompetanse }: Pick<Jobbprofil, 'kompetanse'>) => {
     const kompetanser =

--- a/src/components/cv/kurs.tsx
+++ b/src/components/cv/kurs.tsx
@@ -3,7 +3,7 @@ import Informasjonsbolk from '../felles/informasjonsbolk';
 import { formaterDato, formaterVarighet } from '../../utils/formater';
 import { safeMap, safeSort } from '../../utils';
 import { BodyShort } from '@navikt/ds-react';
-import { ReactComponent as KursIkon } from './ikoner/kurs.svg';
+import Kursikon from './ikoner/kurs.svg?react';
 
 const Kurs = ({ kurs }: Pick<ArenaPerson, 'kurs'>) => {
     const sortedKurs = kurs.sort((a, b) => safeSort(b.tidspunkt, a.tidspunkt));
@@ -28,7 +28,7 @@ const Kurs = ({ kurs }: Pick<ArenaPerson, 'kurs'>) => {
     ));
 
     return (
-        <Informasjonsbolk header="Kurs" icon={<KursIkon aria-hidden="true" />} headerTypo="ingress">
+        <Informasjonsbolk header="Kurs" icon={<Kursikon aria-hidden="true" />} headerTypo="ingress">
             {mappedKurs}
         </Informasjonsbolk>
     );

--- a/src/components/cv/sprak.tsx
+++ b/src/components/cv/sprak.tsx
@@ -2,7 +2,7 @@ import { ArenaPerson, SprakNiva } from '../../data/api/datatyper/arenaperson';
 import Informasjonsbolk from '../felles/informasjonsbolk';
 import { safeMap } from '../../utils';
 import { BodyShort } from '@navikt/ds-react';
-import { ReactComponent as Sprakikon } from './ikoner/sprak.svg';
+import Sprakikon from './ikoner/sprak.svg?react';
 
 // String er lagt til for bakoverkompatibilitet
 function mapSprakNivaTilTekst(sprakNiva: SprakNiva | string): string {

--- a/src/components/cv/utdanning.tsx
+++ b/src/components/cv/utdanning.tsx
@@ -3,7 +3,7 @@ import Informasjonsbolk from '../felles/informasjonsbolk';
 import { formaterDato } from '../../utils/formater';
 import { safeMap, safeSort } from '../../utils';
 import { BodyShort } from '@navikt/ds-react';
-import { ReactComponent as Utdanningsikon } from './ikoner/utdanning.svg';
+import Utdanningsikon from './ikoner/utdanning.svg?react';
 
 const Utdanning = ({ utdanning }: Pick<ArenaPerson, 'utdanning'>) => {
     const sortedUtdanning = utdanning.sort((a, b) => safeSort(b.tilDato, a.tilDato));

--- a/src/components/felles/informasjonsbolk.tsx
+++ b/src/components/felles/informasjonsbolk.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { BodyShort, Heading } from '@navikt/ds-react';
-import '../../../index.css';
 
 interface Props {
     header: string;

--- a/src/components/fellesStyling.css
+++ b/src/components/fellesStyling.css
@@ -76,3 +76,8 @@
     display: flex;
     justify-content: flex-end;
 }
+
+#arbeidsforholdikon {
+    height: 1.5rem;
+    width: 1.5rem;
+}

--- a/src/components/personalia/telefon.tsx
+++ b/src/components/personalia/telefon.tsx
@@ -14,14 +14,13 @@ function TelefonNrMedKilde(props: { telefon: PersonaliaTelefon }) {
                 {formaterTelefonnummer(telefonNr)}
                 <CopyButton copyText={telefonNr} size="xsmall" />
             </BodyShort>
-            <div className="tlf_registrert">
-                {telefonNr && (
-                    <Detail className="kilde_tekst">
-                        Registrert {registrertDato && registrertDato}
-                        {` ${hentKilde(master)}`}
-                    </Detail>
-                )}
-            </div>
+
+            {telefonNr && (
+                <Detail className="kilde_tekst">
+                    Registrert {registrertDato && registrertDato}
+                    {` ${hentKilde(master)}`}
+                </Detail>
+            )}
         </>
     );
 }
@@ -36,9 +35,7 @@ function Telefon({ telefon }: Pick<PersonaliaInfo, 'telefon'>) {
             <BodyShort size="small" className="body_header">
                 Telefon
             </BodyShort>
-            <BodyShort size="small" className="enkeltinfo_value">
-                {telefonListe}
-            </BodyShort>
+            <div className="enkeltinfo_value">{telefonListe}</div>
         </>
     );
 }

--- a/src/components/registrering/personverninformasjon-manuell.tsx
+++ b/src/components/registrering/personverninformasjon-manuell.tsx
@@ -1,4 +1,5 @@
 import { BodyShort, Heading, Link } from '@navikt/ds-react';
+import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import './registrering.css';
 
 function PersonverninformasjonManuell() {
@@ -22,7 +23,7 @@ function PersonverninformasjonManuell() {
                     Du har krav på at NAV vurderer behovet ditt for veiledning. Dette er en rettighet du har etter
                     NAV-loven § 14a se{' '}
                     <Link href="https://lovdata.no/NL/lov/2006-06-16-20/%C2%A714a">
-                        https://lovdata.no/NL/lov/2006-06-16-20/%C2%A714a
+                        https://lovdata.no/NL/lov/2006-06-16-20/%C2%A714a <ExternalLinkIcon />
                     </Link>
                     .
                 </li>
@@ -67,7 +68,7 @@ function PersonverninformasjonManuell() {
             <Heading level="2" size="xsmall">
                 Behandling av personopplysninger
             </Heading>
-            <BodyShort size="small" spacing={true}>
+            <BodyShort size="small" spacing>
                 Opplysningene dine blir lagret etter arkivloven. NAV bruker anonymiserte personopplysninger om
                 arbeidssøkere til å lage offentlig statistikk om arbeidsmarkedet. Les mer om hvordan NAV behandler
                 personopplysninger på <Link href="https://www.nav.no/personvern">https://www.nav.no/personvern</Link>.

--- a/src/components/registrering/personverninformasjon-utskrift.tsx
+++ b/src/components/registrering/personverninformasjon-utskrift.tsx
@@ -32,10 +32,14 @@ function PersonverninformasjonUtskrift(props: { type?: RegistreringType }) {
             >
                 Personverninformasjon, rettigheter og plikter
             </Button>
-            <Modal className="personvern_modal" open={visPrintModal} onClose={() => setVisPrintModal(false)}>
-                <PrintKnappModal />
-                {erSykmeldt(props.type) && <PersonverninformasjonSykmeldt />}
-                {erOrdinaer(props.type) && <PersonverninformasjonManuell />}
+            <Modal id="personvern_modal" open={visPrintModal} onClose={() => setVisPrintModal(false)}>
+                <Modal.Header>
+                    <PrintKnappModal />
+                </Modal.Header>
+                <Modal.Body>
+                    {erSykmeldt(props.type) && <PersonverninformasjonSykmeldt />}
+                    {erOrdinaer(props.type) && <PersonverninformasjonManuell />}
+                </Modal.Body>
             </Modal>
         </>
     );

--- a/src/components/registrering/print-knapp-modal.tsx
+++ b/src/components/registrering/print-knapp-modal.tsx
@@ -11,18 +11,10 @@ export function PrintKnappModal() {
             tittel: 'Personverninformasjon, rettigheter og plikter'
         }
     });
-    const printModal = () => {
-        const modalWrapper = document.getElementById('modal-a11y-wrapper');
-        if (modalWrapper) {
-            modalWrapper.style.display = 'none';
-            window.print();
-            modalWrapper.style.display = 'block';
-        }
-    };
 
     return (
         <div className="personvern_modal_header">
-            <Button variant="primary" type="button" onClick={printModal}>
+            <Button variant="primary" type="button" onClick={() => window.print()}>
                 Skriv ut
             </Button>
         </div>

--- a/src/components/registrering/print-knapp-modal.tsx
+++ b/src/components/registrering/print-knapp-modal.tsx
@@ -3,18 +3,21 @@ import './registrering.css';
 import { trackAmplitude } from '../../amplitude/amplitude';
 
 export function PrintKnappModal() {
-    trackAmplitude({
-        name: 'last ned',
-        data: {
-            type: 'saksdokument',
-            tema: 'personvernsinformasjon',
-            tittel: 'Personverninformasjon, rettigheter og plikter'
-        }
-    });
+    const handleBtnClick = () => {
+        trackAmplitude({
+            name: 'last ned',
+            data: {
+                type: 'saksdokument',
+                tema: 'personvernsinformasjon',
+                tittel: 'Personverninformasjon, rettigheter og plikter'
+            }
+        });
+        window.print();
+    };
 
     return (
         <div className="personvern_modal_header">
-            <Button variant="primary" type="button" onClick={() => window.print()}>
+            <Button variant="primary" type="button" onClick={handleBtnClick}>
                 Skriv ut
             </Button>
         </div>

--- a/src/components/registrering/registrering.css
+++ b/src/components/registrering/registrering.css
@@ -1,30 +1,3 @@
-.personvern_modal {
+#personvern_modal {
     font-size: var(--a-font-size-medium);
-    max-width: 45rem;
-    margin: 0 auto;
-    padding: var(--a-spacing-4);
-}
-
-.personvern_modal_header {
-    border-bottom: var(--a-spacing-05) solid var(--a-gray-400);
-    padding-bottom: var(--a-spacing-4);
-}
-
-.personvern_modal_innhold {
-    padding: var(--a-spacing-4) var(--a-spacing-2);
-}
-
-.personvern_modal_innhold ul {
-    margin-top: var(--a-spacing-1);
-    margin-bottom: var(--a-spacing-1);
-    margin-left: var(--a-spacing-1);
-}
-
-.personvern_modal_innhold p {
-    margin-left: var(--a-spacing-6);
-}
-
-.personvern_modal_innhold h2 {
-    margin-top: var(--a-spacing-2);
-    margin-left: var(--a-spacing-3);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "noEmit": true,
-        "jsx": "react-jsx",
+        "jsx": "preserve",
         /* Linting */
         "strict": true,
         "noUnusedLocals": true,


### PR DESCRIPTION
På grunn av hvordan de nye modalene fungerer så ble det litt CSS-knot for å få til printingen, istedenfor å lage en provider på rot-nivå som det var før. Funker som forventet i Edge og Chrome. Funker (bedre enn før) i Firefox, men den lager dobbelt opp av informasjonen.
Oppdaterte pakker, måtte endre importen av våre egne ikoner som følge av den nye versjonen av `vite-plugin-svgr`.