### PR TITLE
Bugfiks: høyde på appen uten innhold

### DIFF
--- a/src/WebComponentWrapper.tsx
+++ b/src/WebComponentWrapper.tsx
@@ -16,6 +16,7 @@ export class Veilarbdetaljer extends HTMLElement {
         super();
         this.#root = document.createElement('div');
         this.#root.id = WEB_COMPONENT_APPNAVN;
+        this.#root.style.height = '100%';
     }
 
     static get observedAttributes() {


### PR DESCRIPTION
Gjør at den grå bakgrunnen strekker seg til bunnen og det ikke blir et hvitt felt når man ikke har noenbokser synlige