### PR TITLE
Sende med behandlingsnummer for hent-person

### DIFF
--- a/src/components/nokkelinfo.tsx
+++ b/src/components/nokkelinfo.tsx
@@ -40,7 +40,7 @@ const Nokkelinfoinnhold = () => {
     } = useOppfolgingsstatus(fnr);
     const { data: personData, error: personError, isLoading: personLoading } = usePersonalia(fnr, behandlingsnummer);
     const { data: registreringData, error: registreringError, isLoading: registreringLoading } = useRegistrering(fnr);
-    const { data: tolkData, error: tolkError, isLoading: tolkLoading } = useTolk(fnr);
+    const { data: tolkData, error: tolkError, isLoading: tolkLoading } = useTolk(fnr, behandlingsnummer);
     const { data: ytelserData, error: ytelserError, isLoading: ytelserLoading } = useYtelser(fnr);
     const {
         data: cvOgJobbonskerData,

--- a/src/components/nokkelinfo.tsx
+++ b/src/components/nokkelinfo.tsx
@@ -31,13 +31,14 @@ import './nokkelinfo.css';
 
 const Nokkelinfoinnhold = () => {
     const { fnr } = useAppStore();
+    const behandlingsnummer = 'B640';
 
     const {
         data: oppfolgingsstatusData,
         error: oppfolgingsstatusError,
         isLoading: oppfolgingsstatusLoading
     } = useOppfolgingsstatus(fnr);
-    const { data: personData, error: personError, isLoading: personLoading } = usePersonalia(fnr);
+    const { data: personData, error: personError, isLoading: personLoading } = usePersonalia(fnr, behandlingsnummer);
     const { data: registreringData, error: registreringError, isLoading: registreringLoading } = useRegistrering(fnr);
     const { data: tolkData, error: tolkError, isLoading: tolkLoading } = useTolk(fnr);
     const { data: ytelserData, error: ytelserError, isLoading: ytelserLoading } = useYtelser(fnr);

--- a/src/components/nokkelinfo.tsx
+++ b/src/components/nokkelinfo.tsx
@@ -28,10 +28,11 @@ import { finnAlder, kalkulerAlder } from '../utils/date-utils';
 import { EnkeltInformasjonMedCopy } from './felles/enkeltInfoMedCopy';
 import EMDASH from '../utils/emdash';
 import './nokkelinfo.css';
+import { hentBehandlingsnummer } from '../utils/konstanter.ts';
 
 const Nokkelinfoinnhold = () => {
     const { fnr } = useAppStore();
-    const behandlingsnummer = 'B640';
+    const behandlingsnummer = hentBehandlingsnummer();
 
     const {
         data: oppfolgingsstatusData,

--- a/src/components/personalia-innhold.tsx
+++ b/src/components/personalia-innhold.tsx
@@ -16,13 +16,14 @@ import { EndrePersonopplysninger } from './personalia/endre-personopplysninger.t
 
 const Personaliainnhold = () => {
     const { fnr } = useAppStore();
+    const behandlingsnummer = 'B640';
 
     const { data: personData, error: personError, isLoading: personLoading } = usePersonalia(fnr);
     const {
         data: vergeOgFullmaktData,
         error: vergeOgFullmaktError,
         isLoading: vergeOgFullmaktLoading
-    } = useVergeOgFullmakt(fnr);
+    } = useVergeOgFullmakt(fnr, behandlingsnummer);
 
     const MAX_ALDER_BARN = 21;
     const barn: PersonsBarn[] =

--- a/src/components/personalia-innhold.tsx
+++ b/src/components/personalia-innhold.tsx
@@ -13,10 +13,11 @@ import { usePersonalia, useVergeOgFullmakt } from '../data/api/fetch';
 import Kontaktinformasjon from './personalia/kontaktinformasjon';
 import LandOgSprak from './personalia/landOgSprak';
 import { EndrePersonopplysninger } from './personalia/endre-personopplysninger.tsx';
+import { hentBehandlingsnummer } from '../utils/konstanter.ts';
 
 const Personaliainnhold = () => {
     const { fnr } = useAppStore();
-    const behandlingsnummer = 'B640';
+    const behandlingsnummer = hentBehandlingsnummer();
 
     const { data: personData, error: personError, isLoading: personLoading } = usePersonalia(fnr);
     const {

--- a/src/components/personalia/kontaktinformasjon.tsx
+++ b/src/components/personalia/kontaktinformasjon.tsx
@@ -12,10 +12,11 @@ import Informasjonsbolk from '../felles/informasjonsbolk';
 import Adresser from './adresser';
 import Epost from './e-post';
 import Telefon from './telefon';
+import { hentBehandlingsnummer } from '../../utils/konstanter.ts';
 
 const Kontaktinformasjon = () => {
     const { fnr } = useAppStore();
-    const behandlingsnummer = 'B640';
+    const behandlingsnummer = hentBehandlingsnummer();
 
     const person = usePersonalia(fnr, behandlingsnummer);
 

--- a/src/components/personalia/kontaktinformasjon.tsx
+++ b/src/components/personalia/kontaktinformasjon.tsx
@@ -15,8 +15,9 @@ import Telefon from './telefon';
 
 const Kontaktinformasjon = () => {
     const { fnr } = useAppStore();
+    const behandlingsnummer = 'B640';
 
-    const person = usePersonalia(fnr);
+    const person = usePersonalia(fnr, behandlingsnummer);
 
     const telefon: PersonaliaTelefon[] = person.data?.telefon ?? [];
     const epost: OrNothing<PersonaliaEpost> = person.data?.epost;

--- a/src/components/personalia/landOgSprak.tsx
+++ b/src/components/personalia/landOgSprak.tsx
@@ -12,9 +12,10 @@ import { hentMalform } from '../../utils/konstanter';
 
 const LandOgSprak = () => {
     const { fnr } = useAppStore();
+    const behandlingsnummer = 'B640';
 
     const person = usePersonalia(fnr);
-    const { data: tolkData, error: tolkError, isLoading: tolkLoading } = useTolk(fnr);
+    const { data: tolkData, error: tolkError, isLoading: tolkLoading } = useTolk(fnr, behandlingsnummer);
 
     const statsborgerskap: string[] = person.data?.statsborgerskap ?? [];
     const tilrettelagtKommunikasjon: OrNothing<TilrettelagtKommunikasjonData> = tolkData;

--- a/src/components/personalia/landOgSprak.tsx
+++ b/src/components/personalia/landOgSprak.tsx
@@ -8,11 +8,11 @@ import { Errormelding, Laster } from '../felles/minikomponenter';
 import StatsborgerskapInfo from './statsborgerskapinfo';
 import TilrettelagtKommunikasjon from './tilrettelagtKommunikasjon';
 import { EnkeltInformasjon } from '../felles/enkeltInfo';
-import { hentMalform } from '../../utils/konstanter';
+import { hentBehandlingsnummer, hentMalform } from '../../utils/konstanter';
 
 const LandOgSprak = () => {
     const { fnr } = useAppStore();
-    const behandlingsnummer = 'B640';
+    const behandlingsnummer = hentBehandlingsnummer();
 
     const person = usePersonalia(fnr);
     const { data: tolkData, error: tolkError, isLoading: tolkLoading } = useTolk(fnr, behandlingsnummer);

--- a/src/data/api/fetch.ts
+++ b/src/data/api/fetch.ts
@@ -157,10 +157,10 @@ export const useEndringIRegistrering = (fnr?: string) => {
     return { data, isLoading, error };
 };
 
-export const useTolk = (fnr?: string) => {
+export const useTolk = (fnr?: string, behandlingsnummer?: string) => {
     const url = '/veilarbperson/api/v3/person/hent-tolk';
     const { data, error, isLoading } = useSWR<TilrettelagtKommunikasjonData, ErrorMessage>(fnr ? url : null, () =>
-        fetchWithPost(url, { fnr: fnr ?? null })
+        fetchWithPost(url, { fnr: fnr ?? null, behandlingsnummer: behandlingsnummer })
     );
 
     return { data, isLoading, error };

--- a/src/data/api/fetch.ts
+++ b/src/data/api/fetch.ts
@@ -28,6 +28,11 @@ export interface overblikkVisningResponse {
     overblikkVisning: string[];
 }
 
+export interface pdlRequest {
+    fnr: string | null;
+    behandlingsnummer: string | null;
+}
+
 export interface Fnr {
     fnr: string | null;
 }
@@ -65,7 +70,7 @@ const fetcher = async (url: string) => {
     return handterRespons(respons);
 };
 
-const fetchWithPost = async (url: string, requestBody: FrontendEvent | overblikkVisningRequest | Fnr) => {
+const fetchWithPost = async (url: string, requestBody: FrontendEvent | overblikkVisningRequest | pdlRequest | Fnr) => {
     const respons = await fetch(url, createPOSToptions(requestBody));
     return handterRespons(respons);
 };
@@ -125,10 +130,10 @@ export const useOppfolgingsstatus = (fnr?: string) => {
     return { data, isLoading, error };
 };
 
-export const usePersonalia = (fnr?: string) => {
+export const usePersonalia = (fnr?: string, behandlingsnummer?: string) => {
     const url = '/veilarbperson/api/v3/hent-person';
     const { data, error, isLoading } = useSWR<PersonaliaInfo, ErrorMessage>(fnr ? url : null, () =>
-        fetchWithPost(url, { fnr: fnr ?? null })
+        fetchWithPost(url, { fnr: fnr ?? null, behandlingsnummer: behandlingsnummer })
     );
 
     return { data, isLoading, error };
@@ -161,10 +166,10 @@ export const useTolk = (fnr?: string) => {
     return { data, isLoading, error };
 };
 
-export const useVergeOgFullmakt = (fnr?: string) => {
+export const useVergeOgFullmakt = (fnr?: string, behandlingsnummer?: string) => {
     const url = '/veilarbperson/api/v3/person/hent-vergeOgFullmakt';
     const { data, error, isLoading } = useSWR<VergeOgFullmaktData, ErrorMessage>(fnr ? url : null, () =>
-        fetchWithPost(url, { fnr: fnr ?? null })
+        fetchWithPost(url, { fnr: fnr ?? null, behandlingsnummer: behandlingsnummer })
     );
 
     return { data, isLoading, error };

--- a/src/utils/konstanter.ts
+++ b/src/utils/konstanter.ts
@@ -72,3 +72,7 @@ export function hentMalform(malform: OrNothing<string>) {
             return EMDASH;
     }
 }
+
+export function hentBehandlingsnummer() {
+    return 'B640';
+}


### PR DESCRIPTION
Hva er poenget med denne PR-en?
Denne PR-en står i sammenheng med https://github.com/navikt/veilarbperson/pull/289, men kan prodsettes uavhengig av den.

1. PDL ber om at vi sender med behandlingsnummer fra behandlingskatalogen ved requester mot PDL
2. Behandlingskatalogen er organisert etter frontender (Overblikk, Oversikten, Visittkort, etc)
3. Vi identifiserer at 3 frontendapper bruker endepunktene i veilarbperson som går videre til PDL (Overblikk, Visittkort og Mulighetsrommet)
4. I samråd med Ingunn bestemmer vi at vi skal få appene som bruker endepunktene til å sende inn behandlingsnummer selv
5. Jeg har derfor lagt til en ny type for requestbody for PDL-requester i veilarbperson. (Den godtar at behandlingsnummeret er null/tomt)
6. Jeg sender med behandlingsnummer fra frontendene (som er i denne PR-en)