### PR TITLE
bugfiks: Kun skjule profileringen dersom vedtaket faktisk er fattet i denne oppfølgingsperioden

### DIFF
--- a/src/components/registrering/arbeidssoekerregistrering/foreslatt-profilering.tsx
+++ b/src/components/registrering/arbeidssoekerregistrering/foreslatt-profilering.tsx
@@ -1,6 +1,11 @@
 import { BodyShort, Box, Heading, Loader } from '@navikt/ds-react';
 import { profilertTilBeskrivelse } from '../../../utils/text-mapper';
-import { useSiste14aVedtak } from '../../../data/api/fetch';
+import {
+    GjeldendeOppfolgingsperiode,
+    Siste14aVedtak,
+    useGjeldendeOppfolgingsperiode,
+    useSiste14aVedtak
+} from '../../../data/api/fetch';
 import { Profilering } from '@navikt/arbeidssokerregisteret-utils';
 
 interface Props {
@@ -14,12 +19,36 @@ export const ForeslattProfilering = ({ fnr, profilering }: Props) => {
         error: siste14avedtakError,
         isLoading: siste14avedtakLoading
     } = useSiste14aVedtak(fnr);
+    const {
+        data: gjeldendeOppfolgingsperiode,
+        error: gjeldendeOppfolgingsperiodeError,
+        isLoading: gjeldendeOppfolgingsperiodeLoading
+    } = useGjeldendeOppfolgingsperiode(fnr);
 
-    if (siste14avedtakLoading) {
+    if (siste14avedtakLoading || gjeldendeOppfolgingsperiodeLoading) {
         return <Loader size="small" />;
     }
 
-    if (siste14avedtakError || siste14avedtak != null) {
+    const detErFattetVedtakIDenneOppfolgingsperioden = (
+        gjeldendeOppfolgingsperiode?: GjeldendeOppfolgingsperiode,
+        siste14avedtak?: Siste14aVedtak
+    ) => {
+        if (!siste14avedtak) {
+            return false;
+        }
+        const periodeStartetdato = gjeldendeOppfolgingsperiode?.startDato
+            ? Date.parse(gjeldendeOppfolgingsperiode.startDato.toString())
+            : null;
+        const vedtakFattetDato = siste14avedtak?.fattetDato ? Date.parse(siste14avedtak.fattetDato) : null;
+
+        return periodeStartetdato && vedtakFattetDato && vedtakFattetDato > periodeStartetdato;
+    };
+
+    if (
+        siste14avedtakError ||
+        gjeldendeOppfolgingsperiodeError ||
+        detErFattetVedtakIDenneOppfolgingsperioden(gjeldendeOppfolgingsperiode, siste14avedtak)
+    ) {
         return null;
     }
 

--- a/src/data/api/fetch.ts
+++ b/src/data/api/fetch.ts
@@ -37,11 +37,17 @@ export interface Fnr {
     fnr: string | null;
 }
 
-interface Siste14aVedtak {
+export interface Siste14aVedtak {
     innsatsgruppe: string;
     hovedmal: string;
     fattetDato: string;
     fraArena: boolean;
+}
+
+export interface GjeldendeOppfolgingsperiode {
+    uuid: string;
+    startDato: Date;
+    sluttDato: Date;
 }
 
 export interface OpplysningerOmArbeidssokerMedProfilering {
@@ -69,7 +75,7 @@ const handterRespons = async (respons: Response) => {
     }
 
     try {
-        return await respons.json();
+        return await respons.text().then((res) => (!res ? null : JSON.parse(res)));
     } catch (err) {
         throw {
             error: err,
@@ -220,6 +226,16 @@ export const useVeileder = (veilederId: StringOrNothing) => {
     const { data, error, isLoading } = useSWR<VeilederData, ErrorMessage>(
         veilederId ? `/veilarbveileder/api/veileder/` + veilederId : null,
         fetcher
+    );
+
+    return { data, isLoading, error };
+};
+
+export const useGjeldendeOppfolgingsperiode = (fnr?: string) => {
+    const url = `/veilarboppfolging/api/v3/oppfolging/hent-gjeldende-periode`;
+    const { data, error, isLoading } = useSWR<GjeldendeOppfolgingsperiode, ErrorMessage>(
+        fnr ? `${url}/${fnr}fnr` : null,
+        () => fetchWithPost(url, { fnr: fnr ?? null })
     );
 
     return { data, isLoading, error };


### PR DESCRIPTION
Vi har tatt et valg om at dersom man har fattet et 14a-vedtak skal vi skjule profileringen fordi man kan gå igjennom skjema flere ganger, men man skal ikke nødvendigvis fatte nye vedtak basert på det. Derfor skjuler vi profileringen dersom man allerede har et 14a-vedtak i gjeldende oppfølgingsperiode. 