### PR TITLE
Vise registrert dato og at man har en aktiv arbeidssøkerperiode selv man ikke har lagret opplysninger om arbeidssøker

### DIFF
--- a/src/components/registrering-innhold.tsx
+++ b/src/components/registrering-innhold.tsx
@@ -16,6 +16,10 @@ const Registreringsinnhold = () => {
 
     const harIkkeRegistrering =
         opplysningerOmArbedissoekerMedProfileringError?.status == 204 ||
+        !opplysningerOmArbedissoekerMedProfilering?.arbeidssoekerperiodeStartet;
+
+    const harIkkeOpplysningerMenErRegistrert =
+        !!opplysningerOmArbedissoekerMedProfilering?.arbeidssoekerperiodeStartet &&
         !opplysningerOmArbedissoekerMedProfilering?.opplysningerOmArbeidssoeker;
 
     if (opplysningerOmArbedissoekerMedProfileringLoading) {
@@ -26,6 +30,13 @@ const Registreringsinnhold = () => {
         return (
             <Alert inline variant="info" size="small">
                 Brukeren har ikke registrert seg i Arbeidssøkerregisteret og har ikke en aktiv arbeidssøkerperiode.
+            </Alert>
+        );
+    } else if (harIkkeOpplysningerMenErRegistrert) {
+        return (
+            <Alert inline variant="warning" size="small">
+                Brukeren har en aktiv arbeidssøkerperiode, men vi klarer ikke hente opplysninger om arbeidssøker fra
+                arbeidssøkerregisteret.
             </Alert>
         );
     } else if (opplysningerOmArbedissoekerMedProfileringError) {


### PR DESCRIPTION
Vise at personen har en aktiv arbeidssøkerperiode, men ingen opplysninger: https://nav-it.slack.com/archives/C061Z54S4H3/p1734688772016519
