### PR TITLE
Gå over til nav-cdn i steden for egen bucket

### DIFF
--- a/.github/workflows/last-opp-statiske-filer-til-gcs-dev.yaml
+++ b/.github/workflows/last-opp-statiske-filer-til-gcs-dev.yaml
@@ -43,12 +43,3 @@ jobs:
                 no_cache_paths: dev/veilarbdetaljerfs/dist/asset-manifest.json
                 identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
                 project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-            - name: Authenticate to Google Cloud
-              uses: google-github-actions/auth@v2
-              with:
-                  workload_identity_provider: projects/773963069019/locations/global/workloadIdentityPools/github/providers/github-action
-                  service_account: veilarbdetaljerfs-gcs@obo-dev-1713.iam.gserviceaccount.com
-            - name: Set up Cloud SDK
-              uses: google-github-actions/setup-gcloud@v2
-            - name: Upload files to GCS
-              run: gsutil -m rsync -r dist gs://obo-veilarbdetaljerfs-dev

--- a/.github/workflows/last-opp-statiske-filer-til-gcs-prod.yaml
+++ b/.github/workflows/last-opp-statiske-filer-til-gcs-prod.yaml
@@ -34,12 +34,12 @@ jobs:
         run: npm run build
         env:
           PUBLIC_URL: https://veilarbdetaljer.intern.nav.no
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+      - name: Upload to Nav CDN
+        uses: nais/deploy/actions/cdn-upload/v2@master
         with:
-          workload_identity_provider: projects/10615342352/locations/global/workloadIdentityPools/github/providers/github-action
-          service_account: veilarbdetaljerfs-gcs@obo-prod-fc62.iam.gserviceaccount.com
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-      - name: Upload files to GCS
-        run: gsutil -m rsync -r dist gs://obo-veilarbdetaljerfs-prod
+          team: obo
+          source: ./dist
+          destination: prod/veilarbdetaljerfs
+          no_cache_paths: prod/veilarbdetaljerfs/dist/asset-manifest.json
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
-    "build": "tsc && vite build --base=https://veilarbdetaljer.intern.nav.no",
+    "build": "tsc && vite build --base=https://cdn.nav.no/obo/prod/veilarbdetaljerfs/dist",
     "build:dev": "tsc && vite build --base=https://cdn.nav.no/obo/dev/veilarbdetaljerfs/dist",
     "lint": "eslint src --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",


### PR DESCRIPTION
Siden vi har endret til å kun hente inn appen i veilarbpersonflate via CDN, så må vi laste opp filene herfra til CDN så endringer faktisk kommer ut i prod.