### PR TITLE
Gjer sjekken for kva vi anser som gjeldande § 14 a-vedtak meir "relaxed"

### DIFF
--- a/src/utils/gjeldende-14a-vedtak.ts
+++ b/src/utils/gjeldende-14a-vedtak.ts
@@ -13,6 +13,10 @@ export const sjekkOmSiste14aVedtakErGjeldende = (
     const gjeldendeOppfolgingsperiodeStartDato = parseISO(gjeldendeOppfolgingsperiode.startDato);
     const oppfolgingsperiodeLanseringsdato = parseISO('2017-12-04T00:00:00+02:00');
 
+    // 2025-02-18
+    // Vi har oppdaget at vedtak fattet i Arena får "fattetDato" lik midnatt den dagen vedtaket ble fattet.
+    // Derfor har vi valgt å innfør en "grace periode" på 4 døgn. Dvs. dersom vedtaket ble fattet etter
+    // "oppfølgingsperiode startdato - 4 døgn", så anser vi det som gjeldende.
     return (
         isAfter(siste14aVedtakfattetDatoIso, subDays(gjeldendeOppfolgingsperiodeStartDato, 4)) ||
         (isBefore(siste14aVedtakfattetDatoIso, oppfolgingsperiodeLanseringsdato) &&


### PR DESCRIPTION
Vi oppdaga at § 14 a-vedtak som vert fatta i Arena får `fattetDato` satt til midnatt den dagen vedtaket vart fatta. Eksempel: dersom ein veiledar fattar vedtak `2025-02-18 11:15:00`, så vil `fattetDato` seie `2025-02-18 00:00:00`. Dette er problematisk sidan personar som får oppfølging starta og § 14 a-vedtak fatta same dag, så vil vi alltid seie at hen ikkje har eit gjeldande vedtak, sjølv om "funksjonell tid" (dvs. tidspunkt når veiledar faktisk gjer vedtaket) i realiteten er _etter_ oppfølging startdato.

Sjå Slack-tråd: https://nav-it.slack.com/archives/CF7DMUHSM/p1739782217530059.

Vi har difor bestemt oss for at vi gjer denne sjekken meir "relaxed", ved at vi samanliknar "vedtak fattet dato" med "oppfølging startdato og 4 døgn bakover i tid".

[TC-949](https://trello.com/c/l4GdGbDn/949-h%C3%A5ndtering-av-feiltreff-i-har-ikke-gjeldende-vedtak)