### PR TITLE
Sette loggdestinasjonar eksplisitt

### DIFF
--- a/.nais/obo-nais-dev.yaml
+++ b/.nais/obo-nais-dev.yaml
@@ -28,6 +28,11 @@ spec:
     requests:
       cpu: 250m
       memory: 256Mi
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   gcp:
     buckets:
       - name: obo-veilarbdetaljerfs-dev

--- a/.nais/obo-nais-prod.yaml
+++ b/.nais/obo-nais-prod.yaml
@@ -27,6 +27,11 @@ spec:
     requests:
       cpu: 250m
       memory: 256Mi
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   gcp:
     buckets:
       - name: obo-veilarbdetaljerfs-prod


### PR DESCRIPTION
[Nais skal/har gått over til Grafana Loki som default loggverktøy og Elastic Kibana er difor deprekert](https://nav-it.slack.com/docs/T5LNAMWNA/F08RNSRJ934). Elastic vil vere tilgjengeleg ut året, så inntil vi får migrert til Grafana Loki, må vi eksplisitt spesifisere Elastic Kibana som loggdestinasjon. Legg difor til både `elastic` og `loki` som loggdestinasjonar slik at vi kan halde fram med å få loggar i Kibana. Når vi er blitt vande nok med Loki kan vi gå over permanent og fjerne `elastic`.