### PR TITLE
Spore klikk på "Melde fra om feil?"- og "Kopier feilkode"-knappane

### DIFF
--- a/src/amplitude/amplitude.ts
+++ b/src/amplitude/amplitude.ts
@@ -15,6 +15,7 @@ declare global {
     }
     /* tslint:enable:no-unused-variable */
 }
+
 export const maskereFodselsnummer = (data?: Record<string, unknown>) => {
     const maskertObjekt = JSON.stringify(data).replace(/\d{11}/g, (_, indexOfMatch, fullString) =>
         fullString.charAt(indexOfMatch - 1) === '"' ? '***********' : '"***********"'
@@ -27,6 +28,7 @@ export const maskereFodselsnummer = (data?: Record<string, unknown>) => {
     }
     return {};
 };
+
 export const trackAmplitude = (
     { name: eventName, data: eventData }: AmplitudeEvent,
     ekstraData?: Record<string, unknown>

--- a/src/amplitude/taxonomy-events.ts
+++ b/src/amplitude/taxonomy-events.ts
@@ -3,4 +3,5 @@ export type AmplitudeEvent =
     | { name: 'navigere'; data: { lenketekst: string; destinasjon: string } }
     | { name: 'last ned'; data: { type: string; tema: string; tittel: string } }
     | { name: 'filtervalg'; data: { kategori: string; filternavn: string } }
-    | { name: 'modal åpnet'; data: { tekst: string } };
+    | { name: 'modal åpnet'; data: { tekst: string } }
+    | { name: 'knapp klikket'; data: { knapptekst: string } };

--- a/src/components/felles/error-alert-med-feilkode.tsx
+++ b/src/components/felles/error-alert-med-feilkode.tsx
@@ -2,16 +2,19 @@ import { Alert, BodyShort, CopyButton, Link, List, ReadMore, VStack } from '@nav
 import './alert-med-feilkode.css';
 import React from 'react';
 import { ListItem } from '@navikt/ds-react/List';
+import { trackAmplitude } from '../../amplitude/amplitude.ts';
 
 /**
  * Props for {@link ErrorAlertMedFeilkode}
  *
  * @param feilkoder en liste av feilkoder, default er `[]`
  * @param children generell feiltekst som vil vises før {@link ReadMore}-en, f.eks. "Noe gikk galt! Prøv igjen om noen minutter"
+ * @param aktiverSporing hvorvidt statistikk for klikk på knapper i komponenten skal spores
  */
 interface ErrorAlertMedFeilkodeProps {
     feilkoder: string[];
     children: string;
+    aktiverSporing?: boolean;
 }
 
 /**
@@ -20,12 +23,27 @@ interface ErrorAlertMedFeilkodeProps {
  * * en liste med feilkoder som bruker kan legge ved når man melder inn feil, gitt at
  * {@link ErrorAlertMedFeilkodeProps.feilkoder} inneholder minst et element
  */
-export const ErrorAlertMedFeilkode = ({ feilkoder, children }: ErrorAlertMedFeilkodeProps) => {
+export const ErrorAlertMedFeilkode = ({ feilkoder, children, aktiverSporing = false }: ErrorAlertMedFeilkodeProps) => {
     return (
         <Alert className="error-alert-med-feilkode__innhold" variant="error" size="small">
             <VStack gap="2">
                 {children}
-                <ReadMore size="small" header="Melde fra om feil?" className="error-alert-med-feilkode__read-more">
+                <ReadMore
+                    className="error-alert-med-feilkode__read-more"
+                    header="Melde fra om feil?"
+                    onClick={
+                        aktiverSporing
+                            ? () =>
+                                  trackAmplitude({
+                                      name: 'knapp klikket',
+                                      data: {
+                                          knapptekst: 'Melde fra om feil?'
+                                      }
+                                  })
+                            : undefined
+                    }
+                    size="small"
+                >
                     <VStack align="start" gap="1">
                         <BodyShort size="small">
                             For å melde inn feil kan du gå til{' '}
@@ -47,6 +65,20 @@ export const ErrorAlertMedFeilkode = ({ feilkoder, children }: ErrorAlertMedFeil
                                 </List>
                                 <CopyButton
                                     copyText={feilkoder.join(', ')}
+                                    onClick={
+                                        aktiverSporing
+                                            ? () =>
+                                                  trackAmplitude({
+                                                      name: 'knapp klikket',
+                                                      data: {
+                                                          knapptekst:
+                                                              feilkoder.length > 1
+                                                                  ? `Kopier feilkoder`
+                                                                  : `Kopier feilkode`
+                                                      }
+                                                  })
+                                            : undefined
+                                    }
                                     size="small"
                                     text={feilkoder.length > 1 ? `Kopier feilkoder` : `Kopier feilkode`}
                                 />

--- a/src/components/nokkelinfo.tsx
+++ b/src/components/nokkelinfo.tsx
@@ -99,7 +99,7 @@ const Nokkelinfoinnhold = () => {
             .filter((korrelasjonId) => korrelasjonId !== null);
 
         return (
-            <ErrorAlertMedFeilkode feilkoder={feilkoder}>
+            <ErrorAlertMedFeilkode feilkoder={feilkoder} aktiverSporing>
                 Noe gikk galt! Prøv igjen om noen minutter.
             </ErrorAlertMedFeilkode>
         );


### PR DESCRIPTION
Vi ønsker å sjå kor mange av dei som får vist denne feilmeldingen klikkar på høvesvis "Melde fra om feil?"- og "Kopier feilkode(r)"-knappane.

Merk; eg har lagt til ein ny hendelsetype:

`| { name: 'knapp klikket'; data: { knapptekst: string } };`

[Denne er henta frå veilarbportefoljeflatefs](https://github.com/navikt/veilarbportefoljeflatefs/blob/3e4368c68fa4973d629483dda01f382c7ec1ef2c/src/amplitude/taxonomy-events.ts#L6) då det er greit å bruke same taxonomi på tvers av løysingane. Einaste endringa er at `effekt`-propertyen som var definert i veilarbportefoljeflatefs ikkje er med her.